### PR TITLE
Allow Deserialize into an existing object. 

### DIFF
--- a/SharpYaml.Tests/Serialization/SerializationTests.cs
+++ b/SharpYaml.Tests/Serialization/SerializationTests.cs
@@ -711,6 +711,42 @@ Name: Charles
 			public string Name { get; set; }
 		}
 
+        public class ExtendedPerson {
+            public string Name { get; set; }
+            public int Age { get; set; }
+        }
+
+        [Test]
+        public void DeserializeIntoExisting() {
+            var serializer = new Serializer();
+            var andy = new ExtendedPerson { Name = "Not Andy", Age = 30 };
+            var yaml = @"---
+Name: Andy
+...";
+            andy = serializer.DeserializeInto<ExtendedPerson>(yaml,andy);
+            Assert.AreEqual("Andy", andy.Name);
+            Assert.AreEqual(30, andy.Age);
+
+            andy = new ExtendedPerson { Name = "Not Andy", Age = 30 };
+            andy = (ExtendedPerson)serializer.Deserialize(yaml, typeof(ExtendedPerson), andy);
+            Assert.AreEqual("Andy", andy.Name);
+            Assert.AreEqual(30, andy.Age);
+
+        }
+
+        [Test]
+        public void DeserializeWithExistingObject() {
+            var serializer = new Serializer();
+            var andy = new ExtendedPerson { Name = "Not Andy", Age = 30 };
+            var yaml = @"---
+Name: Andy
+...";
+            andy = new ExtendedPerson { Name = "Not Andy", Age = 30 };
+            andy = (ExtendedPerson)serializer.Deserialize(yaml, typeof(ExtendedPerson), andy);
+            Assert.AreEqual("Andy", andy.Name);
+            Assert.AreEqual(30, andy.Age);
+        }
+
 		[Test]
 		public void DeserializeEmptyDocument()
 		{

--- a/SharpYaml.Tests/Serialization/SerializationTests.cs
+++ b/SharpYaml.Tests/Serialization/SerializationTests.cs
@@ -747,6 +747,54 @@ Name: Andy
             Assert.AreEqual(30, andy.Age);
         }
 
+        public class Family {
+            public ExtendedPerson Mother { get; set; }
+            public ExtendedPerson Father { get; set; }
+        }
+
+        [Test]
+        public void DeserializeIntoExistingSubObjects() {
+            var serializer = new Serializer();
+            var andy = new ExtendedPerson { Name = "Not Andy", Age = 30 };
+            var amy = new ExtendedPerson { Name = "Amy", Age = 33 };
+            var family = new Family { Father = andy, Mother = amy };
+            var yaml = @"---
+Mother:  
+  Name: Betty
+  Age: 22
+
+Father:
+  Name: Andy
+...";
+            family = serializer.DeserializeInto<Family>(yaml, family);
+            Assert.AreEqual("Andy", family.Father.Name);
+            Assert.AreEqual("Betty", family.Mother.Name);
+            // Existing behaviour will pass with the commented line
+            //Assert.AreEqual(0, family.Father.Age);
+            Assert.AreEqual(30, family.Father.Age);
+            Assert.AreEqual(22, family.Mother.Age);
+        }
+
+        [Test]
+        public void DeserializeWithRepeatedSubObjects() {
+            var serializer = new Serializer();
+            var yaml = @"---
+Mother:  
+  Name: Betty
+  
+Mother:
+  Age: 22
+...";
+            var family = serializer.Deserialize<Family>(yaml);
+            Assert.IsNull(family.Father);
+            // Note: This is the behaviour I would expect
+            // Existing behaviour will pass with the commented line
+            //Assert.IsNull(family.Mother.Name);
+            Assert.AreEqual("Betty", family.Mother.Name);
+            Assert.AreEqual(22, family.Mother.Age);
+        }
+
+
 		[Test]
 		public void DeserializeEmptyDocument()
 		{

--- a/SharpYaml.Tests/SharpYaml.Tests.csproj
+++ b/SharpYaml.Tests/SharpYaml.Tests.csproj
@@ -106,6 +106,9 @@
       <Name>SharpYaml</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/SharpYaml/Serialization/Serializer.cs
+++ b/SharpYaml/Serialization/Serializer.cs
@@ -266,62 +266,67 @@ namespace SharpYaml.Serialization
 			return (T) Deserialize(stream, typeof (T));
 		}
 
-		/// <summary>
-		/// Deserializes an object from the specified <see cref="TextReader" /> with an expected specific type.
-		/// </summary>
-		/// <param name="reader">The reader.</param>
-		/// <param name="expectedType">The expected type.</param>
-		/// <returns>A deserialized object.</returns>
-		/// <exception cref="System.ArgumentNullException">reader</exception>
-		public object Deserialize(TextReader reader, Type expectedType)
+	    /// <summary>
+	    /// Deserializes an object from the specified <see cref="TextReader" /> with an expected specific type.
+	    /// </summary>
+	    /// <param name="reader">The reader.</param>
+	    /// <param name="expectedType">The expected type.</param>
+	    /// <param name="existingObject">The object to deserialize into. If null (the default) then a new object will be created</param>
+	    /// <returns>A deserialized object.</returns>
+	    /// <exception cref="System.ArgumentNullException">reader</exception>
+	    public object Deserialize(TextReader reader, Type expectedType, object existingObject=null)
 		{
 			if (reader == null) throw new ArgumentNullException("reader");
-			return Deserialize(new EventReader(new Parser(reader)), expectedType);
+			return Deserialize(new EventReader(new Parser(reader)), expectedType, existingObject);
 		}
 
-		/// <summary>
-		/// Deserializes an object from the specified <see cref="TextReader" /> with an expected specific type.
-		/// </summary>
-		/// <typeparam name="T">The expected type</typeparam>
-		/// <param name="reader">The reader.</param>
-		/// <returns>A deserialized object.</returns>
-		/// <exception cref="System.ArgumentNullException">reader</exception>
-		public T Deserialize<T>(TextReader reader)
+	    /// <summary>
+	    /// Deserializes an object from the specified <see cref="TextReader" /> with an expected specific type.
+	    /// </summary>
+	    /// <typeparam name="T">The expected type</typeparam>
+	    /// <param name="reader">The reader.</param>
+        /// <param name="existingObject">The object to deserialize into. If null (the default) then a new object will be created</param>
+	    /// <returns>A deserialized object.</returns>
+	    /// <exception cref="System.ArgumentNullException">reader</exception>
+	    public T Deserialize<T>(TextReader reader, object existingObject=null)
 		{
-			return (T) Deserialize(reader, typeof (T));
+			return (T) Deserialize(reader, typeof (T), existingObject);
 		}
 
-		/// <summary>
-		/// Deserializes an object from the specified string.
-		/// </summary>
-		/// <param name="fromText">The text.</param>
-		/// <returns>A deserialized object.</returns>
-		public object Deserialize(string fromText)
+	    /// <summary>
+	    /// Deserializes an object from the specified string.
+	    /// </summary>
+	    /// <param name="fromText">The text.</param>
+        /// <param name="existingObject">The object to deserialize into. If null (the default) then a new object will be created</param>
+	    /// <returns>A deserialized object.</returns>
+	    public object Deserialize(string fromText, object existingObject=null)
 		{
-			return Deserialize(fromText, null);
+			return Deserialize(fromText, null, existingObject);
 		}
 
-		/// <summary>
-		/// Deserializes an object from the specified string. with an expected specific type.
-		/// </summary>
-		/// <param name="fromText">From text.</param>
-		/// <param name="expectedType">The expected type.</param>
-		/// <returns>A deserialized object.</returns>
-		/// <exception cref="System.ArgumentNullException">stream</exception>
-		public object Deserialize(string fromText, Type expectedType)
+	    /// <summary>
+	    /// Deserializes an object from the specified string. with an expected specific type.
+	    /// </summary>
+	    /// <param name="fromText">From text.</param>
+	    /// <param name="expectedType">The expected type.</param>
+        /// <param name="existingObject">The object to deserialize into. If null (the default) then a new object will be created</param>
+	    /// <returns>A deserialized object.</returns>
+	    /// <exception cref="System.ArgumentNullException">stream</exception>
+	    public object Deserialize(string fromText, Type expectedType, object existingObject=null)
 		{
 			if (fromText == null) throw new ArgumentNullException("fromText");
-			return Deserialize(new StringReader(fromText), expectedType);
+			return Deserialize(new StringReader(fromText), expectedType,existingObject);
 		}
 
-		/// <summary>
-		/// Deserializes an object from the specified string. with an expected specific type.
-		/// </summary>
-		/// <typeparam name="T">The expected type</typeparam>
-		/// <param name="fromText">From text.</param>
-		/// <returns>A deserialized object.</returns>
-		/// <exception cref="System.ArgumentNullException">stream</exception>
-		public T Deserialize<T>(string fromText)
+	    /// <summary>
+	    /// Deserializes an object from the specified string. with an expected specific type.
+	    /// </summary>
+	    /// <typeparam name="T">The expected type</typeparam>
+	    /// <param name="fromText">From text.</param>
+        /// <param name="existingObject">The object to deserialize into. If null (the default) then a new object will be created</param>
+	    /// <returns>A deserialized object.</returns>
+	    /// <exception cref="System.ArgumentNullException">stream</exception>
+	    public T Deserialize<T>(string fromText)
 		{
 			return (T) Deserialize(fromText, typeof (T));
 		}
@@ -338,14 +343,43 @@ namespace SharpYaml.Serialization
 			return (T) Deserialize(reader, typeof (T));
 		}
 
-		/// <summary>
-		/// Deserializes an object from the specified <see cref="EventReader" /> with an expected specific type.
-		/// </summary>
-		/// <param name="reader">The reader.</param>
-		/// <param name="expectedType">The expected type.</param>
-		/// <returns>A deserialized object.</returns>
-		/// <exception cref="System.ArgumentNullException">reader</exception>
-		public object Deserialize(EventReader reader, Type expectedType)
+
+        /// <summary>
+        /// Deserializes an object from the specified string. with an expected specific type.
+        /// </summary>
+        /// <typeparam name="T">The expected type</typeparam>
+        /// <param name="fromText">From text.</param>
+        /// <param name="existingObject">The object to deserialize into.</param>
+        /// <returns>A deserialized object.</returns>
+        /// <exception cref="System.ArgumentNullException">stream</exception>
+        /// 
+        /// Note: These need a different name, because otherwise they will conflict with existing Deserialize(string,Type). They are new so the difference should not matter
+        public T DeserializeInto<T>(string fromText, T existingObject) { 
+            return (T)Deserialize(fromText, typeof(T), existingObject);
+        }
+
+        /// <summary>
+        /// Deserializes an object from the specified <see cref="EventReader" /> with an expected specific type.
+        /// </summary>
+        /// <typeparam name="T">The expected type</typeparam>
+        /// <param name="reader">The reader.</param>
+        /// <param name="existingObject">The object to deserialize into.</param>
+        /// <returns>A deserialized object.</returns>
+        /// <exception cref="System.ArgumentNullException">reader</exception>
+        public T DeserializeInto<T>(EventReader reader, T existingObject) {
+            return (T)Deserialize(reader, typeof(T), existingObject);
+        }
+
+
+	    /// <summary>
+	    /// Deserializes an object from the specified <see cref="EventReader" /> with an expected specific type.
+	    /// </summary>
+	    /// <param name="reader">The reader.</param>
+	    /// <param name="expectedType">The expected type.</param>
+	    /// <param name="existingObject">An object to deserialize into. By default a new object will be created</param>
+	    /// <returns>A deserialized object.</returns>
+	    /// <exception cref="System.ArgumentNullException">reader</exception>
+	    public object Deserialize(EventReader reader, Type expectedType, object existingObject = null)
 		{
 			if (reader == null) throw new ArgumentNullException("reader");
 			
@@ -356,7 +390,7 @@ namespace SharpYaml.Serialization
 			if (!reader.Accept<DocumentEnd>() && !reader.Accept<StreamEnd>())
 			{
 			    var context = new SerializerContext(this) {Reader = reader};
-			    result = context.ReadYaml(null, expectedType);
+			    result = context.ReadYaml(existingObject, expectedType);
 			}
 
 			if (hasDocumentStart)

--- a/SharpYaml/Serialization/Serializers/ObjectSerializer.cs
+++ b/SharpYaml/Serialization/Serializers/ObjectSerializer.cs
@@ -201,7 +201,19 @@ namespace SharpYaml.Serialization.Serializers
             // Read the value according to the type
             object memberValue = null;
 
-            if (memberAccessor.SerializeMemberMode == SerializeMemberMode.Content)
+            // TEMPORARY COMMENT
+            // This property changes the treatment of existing members - by setting it to true any existing members will be updated, not reset
+            // This is the behaviour I would expect with deserializing into an existing object, but it is a change that I do not fully understand.            
+            // All tests pass with this true, but it may cause a different result for strangely formed yaml.
+            // In particular, if a property is repeated in the yaml file then the second set will override the first only where values are set
+            // Previously they would have overwritten everything.
+            // See the test DeserializeWithExistingSubObjects
+            // I have separated this into a variable because it may be worth putting somewhere as a configuration setting
+            // I'm not sure where it should go, so I've left it here.
+            // If you're happy with the change then just delete this comment and the variable
+            bool updateExistingMembers = true;
+
+            if (memberAccessor.SerializeMemberMode == SerializeMemberMode.Content || (updateExistingMembers && memberAccessor.SerializeMemberMode == SerializeMemberMode.Assign))
             {
                 memberValue = memberAccessor.Get(objectContext.Instance);
             }


### PR DESCRIPTION
The first two commits here are a simple change that just adds an optional argument to each of the Deserialize functions and passes them through to SerializerContext. From the comments there, and from trying it out, it seems that everything from there should be ok. I have added two new tests to make sure that it all works. 

Deserializing into an existing object is a useful feature for objects that have complex creation processes, or for using a Yaml file to override existing properties. It is a feature that has been requested on StackOverflow at http://stackoverflow.com/questions/27623668/does-yamldotnet-library-support-deserialization-into-existing-object

Note that I could not extend the type qualified Deserialize functions as this would cause a conflict with the existing functions (the type inference in the <T> functions match the signature of the non-typed functions where a Type is passed in). For this reason I have not put option parameters on the Deserialize<T> function but have kept them unchanged and added two new functions -  DeserializeInto<T>. If you would prefer to avoid optional parameters, all of the other functions could follow this same approach, with new functions called DeserializeInto with the object parameter, rather than the optional parameter on Deserialize.

Note that these commits do not change any existing behavior - they simply add some new functionality.

The last commit is potentially more risky. I don't think it will have any impact on most cases, but there are some fringe cases where it could change existing behavior. Also I don't know the code well enough to know if it has any wider impact. All existing tests pass with the change.

The goal of the last change is to allow complex existing objects to be preserved, but have some of its properties change by the yaml file. The existing code will reset all sub-properties that are mentioned in the yaml, even though it may be an existing, configured object. The proposed change has the behaviour I would expect with deserializing into an existing object.

See the test DeserializeWithExistingSubObjects which will break without the change, but pass with it.

All existing tests pass with this true, but it may cause a different result for strangely formed yaml.
In particular, if a object property is repeated in the yaml file then the second set will override the first only where values are set.  Previously they would have overwritten everything.

See the test DeserializeWithRepeatedSubObjects which will break without the change but pass with it. Note that this test is not dependent on the SerializeInto change, and should probably be kept (suitably modified) even if you reject the other changes. Either way it clarifies behavior.

If you look in ObjectSerializer.ReadMembe you will see that I have separated this change into a variable because it may be worth putting somewhere as a configuration setting. I'm not sure where it should go, so I've left it as a local variable in the function.

If you're happy with the change then just delete the temporary comment and the variable.