### PR TITLE
Fixed failing decimal serialization

### DIFF
--- a/SharpYaml.Tests/Serialization/SerializationTests2.cs
+++ b/SharpYaml.Tests/Serialization/SerializationTests2.cs
@@ -203,7 +203,9 @@ Value: World!
 
 			public ulong UInt64 { get; set; }
 
-			public float Float { get; set; }
+		    public decimal Decimal { get; set; }
+
+		    public float Float { get; set; }
 
 			public double Double { get; set; }
 
@@ -235,6 +237,7 @@ ArrayContent: [1, 2]
 Bool: true
 BoolFalse: false
 Byte: 2
+Decimal: 4623451.0232342352463856744563
 Double: 6.6
 Enum: B
 EnumWithFlags: A, B

--- a/SharpYaml/Serialization/Serializers/PrimitiveSerializer.cs
+++ b/SharpYaml/Serialization/Serializers/PrimitiveSerializer.cs
@@ -235,7 +235,7 @@ namespace SharpYaml.Serialization.Serializers
                         text = AppendDecimalPoint(((double)value).ToString("R", CultureInfo.InvariantCulture));
 						break;
 					case TypeCode.Decimal:
-                        text = AppendDecimalPoint(((decimal)value).ToString(CultureInfo.InvariantCulture));
+                        text = AppendDecimalPoint(((decimal)value).ToString("G", CultureInfo.InvariantCulture));
 						break;
 					case TypeCode.DateTime:
 						text = ((DateTime) value).ToString("o", CultureInfo.InvariantCulture);

--- a/SharpYaml/Serialization/Serializers/PrimitiveSerializer.cs
+++ b/SharpYaml/Serialization/Serializers/PrimitiveSerializer.cs
@@ -235,7 +235,7 @@ namespace SharpYaml.Serialization.Serializers
                         text = AppendDecimalPoint(((double)value).ToString("R", CultureInfo.InvariantCulture));
 						break;
 					case TypeCode.Decimal:
-                        text = AppendDecimalPoint(((decimal)value).ToString("R", CultureInfo.InvariantCulture));
+                        text = AppendDecimalPoint(((decimal)value).ToString(CultureInfo.InvariantCulture));
 						break;
 					case TypeCode.DateTime:
 						text = ((DateTime) value).ToString("o", CultureInfo.InvariantCulture);


### PR DESCRIPTION
This PR fixes #10 (reported by me a while back). There are two changes:

### SerializationTests2.cs
I added a field to "MyObject" of type decimal, and then added a decimal number into the string in the unit test "TestSimpleObjectAndPrimitive". This causes the test to *fail* due to #10.

### PrimitiveSerializer.cs
Changed the format specifier for decimals from "R" (used for other *floating* precision types) and replaced it with format specifier "G" (used for other *fixed* precision types). This causes the test mentioned above to *pass*, thus fixing #10 