### PR TITLE
Remove YamlValue equality overrides

### DIFF
--- a/SharpYaml.Tests/YamlNodeTest.cs
+++ b/SharpYaml.Tests/YamlNodeTest.cs
@@ -18,7 +18,7 @@ namespace SharpYaml.Tests {
             var fileStream = new StreamReader(file);
             var stream = YamlStream.Load(fileStream);
 
-            var collectionIndicators = ((YamlMapping)((YamlMapping)stream[0].Contents)[new YamlValue("Collection indicators")]);
+            var collectionIndicators = ((YamlMapping)((YamlMapping)stream[0].Contents)["Collection indicators"]);
 
             var firstCollectionIndicator = collectionIndicators.Keys.First();
 
@@ -37,7 +37,7 @@ namespace SharpYaml.Tests {
 
             stream = YamlStream.Load(new StringReader(serialized.ToString()));
 
-            collectionIndicators = ((YamlMapping)((YamlMapping)stream[0].Contents)[new YamlValue("Collection indicators")]);
+            collectionIndicators = ((YamlMapping)((YamlMapping)stream[0].Contents)["Collection indicators"]);
 
             firstCollectionIndicator = collectionIndicators.Keys.First();
 

--- a/SharpYaml/Model/YamlValue.cs
+++ b/SharpYaml/Model/YamlValue.cs
@@ -51,21 +51,6 @@ namespace SharpYaml.Model
             yield return _scalar;
         }
 
-        protected bool Equals(YamlValue other) {
-            return Equals(_scalar.Value, other._scalar.Value);
-        }
-
-        public override bool Equals(object obj) {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != this.GetType()) return false;
-            return Equals((YamlValue)obj);
-        }
-
-        public override int GetHashCode() {
-            return _scalar?.Value?.GetHashCode() ?? 0;
-        }
-
         public override YamlNode DeepClone() {
             return new YamlValue(new Scalar(_scalar.Anchor,
                 _scalar.Tag,


### PR DESCRIPTION
I added the overrides to make it easy to access YamlMapping by string values. But I found that this makes it impossible to use YamlValues with the same string value as distinct keys in a dictionary. So I'm removing the equality overrides and adding an on-demand string lookup table to YamlMapping.