### PR TITLE
Fix round trip floating point bug on x64 platforms

### DIFF
--- a/SharpYaml.Tests/Serialization/SerializationTests.cs
+++ b/SharpYaml.Tests/Serialization/SerializationTests.cs
@@ -968,6 +968,8 @@ Mother:
             [DefaultValue(null)]
             public int? MyNullableWithoutValue { get; set; }
 
+            public double HighPrecisionDouble { get; set; }
+
             public X()
             {
                 MyInt = 1234;
@@ -977,6 +979,10 @@ Mother:
                 MyTimeSpan = TimeSpan.FromHours(1);
                 MyPoint = new Point(100, 200);
                 MyNullableWithValue = 8;
+
+                // This value is used because it fails to round-trip with the "R" format specifier on x64 systems
+                // See https://github.com/dotnet/coreclr/issues/13106 for details.
+                HighPrecisionDouble = 0.84551240822557006;
             }
         }
     }

--- a/SharpYaml.Tests/Serialization/SerializationTests.cs
+++ b/SharpYaml.Tests/Serialization/SerializationTests.cs
@@ -71,23 +71,22 @@ namespace SharpYaml.Tests.Serialization
             Assert.AreEqual(expected, result);
         }
 
-        [Test]
-        public void Roundtrip()
+        private void Roundtrip<T>(SerializerSettings settings)
+            where T : new()
         {
-            var settings = new SerializerSettings();
             settings.RegisterAssembly(typeof(SerializationTests).Assembly);
             var serializer = new Serializer(settings);
 
             var buffer = new StringWriter();
-            var original = new X();
+            var original = new T();
             serializer.Serialize(buffer, original);
 
             Dump.WriteLine(buffer);
 
             var bufferText = buffer.ToString();
-            var copy = serializer.Deserialize<X>(bufferText);
+            var copy = serializer.Deserialize<T>(bufferText);
 
-            foreach (var property in typeof(X).GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            foreach (var property in typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance))
             {
                 if (property.CanRead && property.CanWrite)
                 {
@@ -97,33 +96,15 @@ namespace SharpYaml.Tests.Serialization
                 }
             }
         }
+
+        [Test]
+        public void Roundtrip()
+            => Roundtrip<X>(new SerializerSettings());
 
         [Test]
         public void RoundtripWithDefaults()
-        {
-            var settings = new SerializerSettings() {EmitDefaultValues = true};
-            settings.RegisterAssembly(typeof(SerializationTests).Assembly);
-            var serializer = new Serializer(settings);
+            => Roundtrip<X>(new SerializerSettings() {EmitDefaultValues = true});
 
-            var buffer = new StringWriter();
-            var original = new X();
-            serializer.Serialize(buffer, original);
-
-            Dump.WriteLine(buffer);
-
-            var bufferText = buffer.ToString();
-            var copy = serializer.Deserialize<X>(bufferText);
-
-            foreach (var property in typeof(X).GetProperties(BindingFlags.Public | BindingFlags.Instance))
-            {
-                if (property.CanRead && property.CanWrite)
-                {
-                    Assert.AreEqual(
-                        property.GetValue(original, null),
-                        property.GetValue(copy, null));
-                }
-            }
-        }
 
         [Test]
         public void CircularReference()

--- a/SharpYaml.Tests/Serialization/SerializationTests.cs
+++ b/SharpYaml.Tests/Serialization/SerializationTests.cs
@@ -105,6 +105,9 @@ namespace SharpYaml.Tests.Serialization
         public void RoundtripWithDefaults()
             => Roundtrip<X>(new SerializerSettings() {EmitDefaultValues = true});
 
+        [Test]
+        public void RoundtripFloatingPointEdgeCases()
+            => Roundtrip<FloatingPointEdgeCases>(new SerializerSettings());
 
         [Test]
         public void CircularReference()
@@ -960,10 +963,50 @@ Mother:
                 MyTimeSpan = TimeSpan.FromHours(1);
                 MyPoint = new Point(100, 200);
                 MyNullableWithValue = 8;
+            }
+        }
 
-                // This value is used because it fails to round-trip with the "R" format specifier on x64 systems
-                // See https://github.com/dotnet/coreclr/issues/13106 for details.
-                HighPrecisionDouble = 0.84551240822557006;
+        private class FloatingPointEdgeCases
+        {
+            // This value is used because it fails to round-trip with the "R" format specifier on x64 systems
+            // See https://github.com/dotnet/coreclr/issues/13106 for details.
+            public double HighPrecisionDouble { get; set; } = 0.84551240822557006;
+
+            public double DoubleMax { get; set; } = Double.MaxValue;
+            public double DoubleMin { get; set; } = Double.MinValue;
+            public double DoubleEpsilon { get; set; } = Double.Epsilon;
+
+            public float FloatMax { get; set; } = Single.MaxValue;
+            public float FloatMin { get; set; } = Single.MinValue;
+            public float FloatEpsilon { get; set; } = Single.Epsilon;
+
+            public double DoubleAlmostMax { get; set; }
+            public double DoubleAlmostMin { get; set; }
+
+            public float FloatAlmostMax { get; set; }
+            public float FloatAlmostMin { get; set; }
+
+            public double DoublePositiveInfinity { get; set; } = Double.PositiveInfinity;
+            public double DoubleNegativeInfinity { get; set; } = Double.NegativeInfinity;
+            public double DoubleNaN { get; set; } = Double.NaN;
+
+            public float FloatPositiveInfinity { get; set; } = Single.PositiveInfinity;
+            public float FloatNegativeInfinity { get; set; } = Single.NegativeInfinity;
+            public float FloatNaN { get; set; } = Single.NaN;
+
+            public FloatingPointEdgeCases()
+            {
+                ulong doubleAlmostMaxRaw = BitConverter.ToUInt64(BitConverter.GetBytes(Double.MaxValue), 0) - 1u;
+                DoubleAlmostMax = BitConverter.ToDouble(BitConverter.GetBytes(doubleAlmostMaxRaw), 0);
+
+                ulong doubleAlmostMinRaw = BitConverter.ToUInt64(BitConverter.GetBytes(Double.MinValue), 0) + 1u;
+                DoubleAlmostMin = BitConverter.ToDouble(BitConverter.GetBytes(doubleAlmostMinRaw), 0);
+
+                uint floatAlmostMaxRaw = BitConverter.ToUInt32(BitConverter.GetBytes(Single.MaxValue), 0) - 1;
+                FloatAlmostMax = BitConverter.ToSingle(BitConverter.GetBytes(floatAlmostMaxRaw), 0);
+
+                uint floatAlmostMinRaw = BitConverter.ToUInt32(BitConverter.GetBytes(Single.MinValue), 0) + 1;
+                FloatAlmostMin = BitConverter.ToSingle(BitConverter.GetBytes(floatAlmostMinRaw), 0);
             }
         }
     }

--- a/SharpYaml.Tests/Serialization/SerializationTests2.cs
+++ b/SharpYaml.Tests/Serialization/SerializationTests2.cs
@@ -245,7 +245,7 @@ Byte: 2
 DateTime: 2017-11-20T01:02:03.0000000
 DateTimeOffset: 2017-11-20T01:02:03.0040000+00:00
 Decimal: 4623451.0232342352463856744563
-Double: 6.6
+Double: 6.5999999999999996
 Enum: B
 EnumWithFlags: A, B
 Float: 5.5
@@ -333,8 +333,8 @@ UInt64: 8
             settings.RegisterTagMapping("ObjectFloatDoublePrecision", typeof(ObjectFloatDoublePrecision));
 
             var text = @"!ObjectFloatDoublePrecision
-Double: 1E-05
-Float: 1E-05
+Double: 1.0000000000000001E-05
+Float: 9.99999975E-06
 ".Trim();
 
             SerialRoundTrip(settings, text);

--- a/SharpYaml.Tests/SharpYaml.Tests.csproj
+++ b/SharpYaml.Tests/SharpYaml.Tests.csproj
@@ -23,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE;TEST_DUMP</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/SharpYaml/Serialization/Serializers/PrimitiveSerializer.cs
+++ b/SharpYaml/Serialization/Serializers/PrimitiveSerializer.cs
@@ -261,12 +261,17 @@ namespace SharpYaml.Serialization.Serializers
                         text = ((ulong) value).ToString("G", CultureInfo.InvariantCulture);
                         break;
                     case TypeCode.Single:
-                        //Append decimal point to floating point type values 
-                        //because type changes in round trip conversion if ( value * 10.0 ) % 10.0 == 0
-                        text = AppendDecimalPoint(((float) value).ToString("R", CultureInfo.InvariantCulture), true);
+                        // Append decimal point to floating point type values 
+                        // because type changes in round trip conversion if ( value * 10.0 ) % 10.0 == 0
+                        //
+                        // G9 is used instead of R as per the following documentation:
+                        // https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings#the-round-trip-r-format-specifier
+                        // R can cause issues on x64 systems, see https://github.com/dotnet/coreclr/issues/13106 for details.
+                        text = AppendDecimalPoint(((float) value).ToString("G9", CultureInfo.InvariantCulture), true);
                         break;
                     case TypeCode.Double:
-                        text = AppendDecimalPoint(((double) value).ToString("R", CultureInfo.InvariantCulture), true);
+                        // G17 is used instead of R due to issues on x64 systems. See documentation on TypeCode.Single case above.
+                        text = AppendDecimalPoint(((double) value).ToString("G17", CultureInfo.InvariantCulture), true);
                         break;
                     case TypeCode.Decimal:
                         text = AppendDecimalPoint(((decimal) value).ToString("G", CultureInfo.InvariantCulture), false);


### PR DESCRIPTION
**Short version:** This pull request changes the format string for doubles and floats from `R` to `G17` and `G9` respectively as per the [Standard Numeric Format Strings](https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings#RFormatString) documentation. This fixes round-trip failures for doubles on x64 platforms.

This is essentially the same as #10, except for floating-point numbers.

Note that this commit contains the actual fix: https://github.com/PathogenDavid/SharpYaml/commit/3d3983a4b105e9ddcd282897079be28c8cffc5b5 (The other commits only touch the tests.)

# The problem

The `R` format string does not work as expected on x64 platforms.

The issue is discussed in length in https://github.com/dotnet/coreclr/issues/13106 and the rejected PR https://github.com/dotnet/coreclr/pull/13140, and is documented in both the `R` and `G` sections of the [Standard Numeric Format Strings](https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings#RFormatString) documentation.

----

The bug can be observed by checking out https://github.com/PathogenDavid/SharpYaml/commit/a0dbebfbcff9559f1a166309204e6878b95c7772 (which includes a test for the bug, but does not fix it.)

If you run it in x64 mode `nunit3-console SharpYaml.Tests.exe`, you will get failures.
If you run it in x86 mode `nunit3-console SharpYaml.Tests.exe --x86`, you will not.

# Breaking Change

This change is technically a breaking change (which is why https://github.com/dotnet/coreclr/pull/13140 was eventually rejected.) The deserialized values of previously serialized data should be identical. However, it will likely not serialize to the exact same string.

This is caused by the fact that the `R` format specifier tries to use a more human-friendly shorter representation where possible, whereas `G17` will not. This can be observed on some of the serialization tests which broke as a result of this change: https://github.com/PathogenDavid/SharpYaml/commit/151b38ad7fd381922a8602a450717602b5579a1e

----

In addition to fixing this issue, I've added a test that verifies edge-case floating point values round-trip as expected.