### PR TITLE
When a node is made a child of a node with a tracker, assign the traker to all of the children recursively.

### DIFF
--- a/SharpYaml.Tests/YamlNodeTrackerTest.cs
+++ b/SharpYaml.Tests/YamlNodeTrackerTest.cs
@@ -143,5 +143,38 @@ namespace SharpYaml.Tests {
             Assert.AreEqual("A", ((MappingPairAdded)receivedArgs).Child.Key.ToString());
             Assert.AreEqual("5", ((MappingPairAdded) receivedArgs).Child.Value.ToString());
         }
+
+
+        [Test]
+        public void TrackerAssignmentTest() {
+            var tracker = new YamlNodeTracker();
+            var stream = new YamlStream(tracker);
+
+            var document = new YamlDocument();
+            var sequence = new YamlSequence();
+            document.Contents = sequence;
+
+            var mapping = new YamlMapping();
+            sequence.Add(mapping);
+
+            var key = new YamlValue("key");
+            var value = new YamlValue("value");
+
+            mapping[key] = value;
+
+            Assert.IsNull(document.Tracker);
+            Assert.IsNull(sequence.Tracker);
+            Assert.IsNull(mapping.Tracker);
+            Assert.IsNull(key.Tracker);
+            Assert.IsNull(value.Tracker);
+
+            stream.Add(document);
+
+            Assert.AreEqual(tracker, document.Tracker);
+            Assert.AreEqual(tracker, sequence.Tracker);
+            Assert.AreEqual(tracker, mapping.Tracker);
+            Assert.AreEqual(tracker, key.Tracker);
+            Assert.AreEqual(tracker, value.Tracker);
+        }
     }
 }

--- a/SharpYaml/Model/YamlDocument.cs
+++ b/SharpYaml/Model/YamlDocument.cs
@@ -101,6 +101,16 @@ namespace SharpYaml.Model
             }
         }
 
+        public override YamlNodeTracker Tracker {
+            get { return base.Tracker; }
+            internal set {
+                base.Tracker = value;
+
+                if (_contents != null)
+                    _contents.Tracker = value;
+            }
+        }
+
         public override YamlNode DeepClone() {
             var documentVersionCopy = _documentStart.Version == null
                 ? null

--- a/SharpYaml/Model/YamlMapping.cs
+++ b/SharpYaml/Model/YamlMapping.cs
@@ -41,21 +41,21 @@ namespace SharpYaml.Model {
         }
 
         YamlMapping(MappingStart mappingStart, MappingEnd mappingEnd, List<YamlElement> keys, Dictionary<YamlElement, YamlElement> contents, YamlNodeTracker tracker) {
-            Tracker = tracker;
-
-            MappingStart = mappingStart;
-            this._mappingEnd = mappingEnd;
-
-            if (Tracker == null) {
+            if (tracker == null) {
                 _keys = keys;
                 _contents = contents;
-            }
-            else {
+            } else {
                 _keys = new List<YamlElement>();
                 _contents = new Dictionary<YamlElement, YamlElement>();
+
+                Tracker = tracker;
+
                 foreach (var key in keys)
                     Add(key, contents[key]);
             }
+
+            MappingStart = mappingStart;
+            this._mappingEnd = mappingEnd;
         }
 
         public MappingStart MappingStart {
@@ -209,6 +209,18 @@ namespace SharpYaml.Model {
                 value.Tracker = Tracker;
 
                 Tracker.OnMappingAddPair(this, new KeyValuePair<YamlElement, YamlElement>(key, value), _keys.Count - 1);
+            }
+        }
+
+        public override YamlNodeTracker Tracker {
+            get { return base.Tracker; }
+            internal set {
+                base.Tracker = value;
+
+                foreach (var pair in _contents) {
+                    pair.Key.Tracker = value;
+                    pair.Value.Tracker = value;
+                }
             }
         }
 

--- a/SharpYaml/Model/YamlNode.cs
+++ b/SharpYaml/Model/YamlNode.cs
@@ -30,7 +30,7 @@ using StreamStart = SharpYaml.Events.StreamStart;
 
 namespace SharpYaml.Model {
     public abstract class YamlNode {
-        public YamlNodeTracker Tracker { get; internal set; }
+        public virtual YamlNodeTracker Tracker { get; internal set; }
 
         protected static YamlElement ReadElement(EventReader eventReader, YamlNodeTracker tracker = null) {
             if (eventReader.Accept<MappingStart>())

--- a/SharpYaml/Model/YamlSequence.cs
+++ b/SharpYaml/Model/YamlSequence.cs
@@ -37,22 +37,20 @@ namespace SharpYaml.Model
         }
 
         YamlSequence(SequenceStart sequenceStart, SequenceEnd sequenceEnd, List<YamlElement> contents, YamlNodeTracker tracker) {
-            Tracker = tracker;
-
-            this._sequenceStart = sequenceStart;
-
-            if (Tracker != null)
-                Tracker.OnSequenceStartChanged(this, null, sequenceStart);
-
-            this._sequenceEnd = sequenceEnd;
-
-            if (Tracker == null)
+            if (tracker == null)
                 _contents = contents;
             else {
                 _contents = new List<YamlElement>();
+
+                Tracker = tracker;
+
                 foreach (var item in contents)
                     Add(item);
             }
+
+            SequenceStart = sequenceStart;
+            
+            this._sequenceEnd = sequenceEnd;
         }
 
         public SequenceStart SequenceStart {
@@ -156,6 +154,16 @@ namespace SharpYaml.Model
             if (Tracker != null) {
                 item.Tracker = Tracker;
                 Tracker.OnSequenceAddElement(this, item, _contents.Count - 1);
+            }
+        }
+
+        public override YamlNodeTracker Tracker {
+            get { return base.Tracker; }
+            internal set {
+                base.Tracker = value;
+
+                foreach (var item in _contents)
+                    item.Tracker = value;
             }
         }
 

--- a/SharpYaml/Model/YamlStream.cs
+++ b/SharpYaml/Model/YamlStream.cs
@@ -39,15 +39,16 @@ namespace SharpYaml.Model
         }
 
         YamlStream(StreamStart streamStart, StreamEnd streamEnd, List<YamlDocument> documents, YamlNodeTracker tracker = null) {
-            Tracker = tracker;
-
             this._streamStart = streamStart;
             this._streamEnd = streamEnd;
 
-            if (Tracker == null)
+            if (tracker == null)
                 _documents = documents;
             else {
                 _documents = new List<YamlDocument>();
+
+                Tracker = tracker;
+
                 foreach (var document in documents)
                     Add(document);
             }
@@ -96,6 +97,16 @@ namespace SharpYaml.Model
             if (Tracker != null) {
                 item.Tracker = Tracker;
                 Tracker.OnStreamAddDocument(this, item, _documents.Count - 1);
+            }
+        }
+        
+        public override YamlNodeTracker Tracker {
+            get { return base.Tracker; }
+            internal set {
+                base.Tracker = value;
+
+                foreach (var item in _documents)
+                    item.Tracker = value;
             }
         }
 


### PR DESCRIPTION
I was running into an issue when I would add a node with children to a document, and the children would not get tracked while the main node was.