### PR TITLE
When a node is made a child of a node with a tracker, assign the tracker to all of the children recursively.

### DIFF
--- a/SharpYaml.Tests/YamlNodeTrackerTest.cs
+++ b/SharpYaml.Tests/YamlNodeTrackerTest.cs
@@ -25,7 +25,7 @@ namespace SharpYaml.Tests {
             var fileStream = new StreamReader(file);
             YamlStream.Load(fileStream, tracker);
 
-            Assert.AreEqual(29, childrenAdded);
+            Assert.AreEqual(9, childrenAdded);
         }
 
         [Test]

--- a/SharpYaml/Model/YamlDocument.cs
+++ b/SharpYaml/Model/YamlDocument.cs
@@ -101,6 +101,18 @@ namespace SharpYaml.Model
             }
         }
 
+        public override YamlNodeTracker Tracker {
+            get { return base.Tracker; }
+            internal set {
+                base.Tracker = value;
+
+                if (_contents != null) {
+                    _contents.Tracker = value;
+                    Tracker.OnDocumentContentsChanged(this, null, _contents);
+                }
+            }
+        }
+
         public override YamlNode DeepClone() {
             var documentVersionCopy = _documentStart.Version == null
                 ? null

--- a/SharpYaml/Model/YamlDocument.cs
+++ b/SharpYaml/Model/YamlDocument.cs
@@ -104,6 +104,9 @@ namespace SharpYaml.Model
         public override YamlNodeTracker Tracker {
             get { return base.Tracker; }
             internal set {
+                if (Tracker == value)
+                    return;
+
                 base.Tracker = value;
 
                 if (_contents != null) {

--- a/SharpYaml/Model/YamlMapping.cs
+++ b/SharpYaml/Model/YamlMapping.cs
@@ -215,6 +215,9 @@ namespace SharpYaml.Model {
         public override YamlNodeTracker Tracker {
             get { return base.Tracker; }
             internal set {
+                if (Tracker == value)
+                    return;
+
                 base.Tracker = value;
 
                 for (var i = 0; i < _keys.Count; i++) {

--- a/SharpYaml/Model/YamlMapping.cs
+++ b/SharpYaml/Model/YamlMapping.cs
@@ -41,21 +41,21 @@ namespace SharpYaml.Model {
         }
 
         YamlMapping(MappingStart mappingStart, MappingEnd mappingEnd, List<YamlElement> keys, Dictionary<YamlElement, YamlElement> contents, YamlNodeTracker tracker) {
-            Tracker = tracker;
-
-            MappingStart = mappingStart;
-            this._mappingEnd = mappingEnd;
-
-            if (Tracker == null) {
+            if (tracker == null) {
                 _keys = keys;
                 _contents = contents;
-            }
-            else {
+            } else {
                 _keys = new List<YamlElement>();
                 _contents = new Dictionary<YamlElement, YamlElement>();
+
+                Tracker = tracker;
+
                 foreach (var key in keys)
                     Add(key, contents[key]);
             }
+
+            MappingStart = mappingStart;
+            this._mappingEnd = mappingEnd;
         }
 
         public MappingStart MappingStart {
@@ -209,6 +209,22 @@ namespace SharpYaml.Model {
                 value.Tracker = Tracker;
 
                 Tracker.OnMappingAddPair(this, new KeyValuePair<YamlElement, YamlElement>(key, value), _keys.Count - 1);
+            }
+        }
+
+        public override YamlNodeTracker Tracker {
+            get { return base.Tracker; }
+            internal set {
+                base.Tracker = value;
+
+                for (var i = 0; i < _keys.Count; i++) {
+                    var val = _contents[_keys[i]];
+
+                    _keys[i].Tracker = value;
+                    val.Tracker = value;
+
+                    Tracker.OnMappingAddPair(this, new KeyValuePair<YamlElement, YamlElement>(_keys[i], val), i);
+                }
             }
         }
 

--- a/SharpYaml/Model/YamlNode.cs
+++ b/SharpYaml/Model/YamlNode.cs
@@ -30,7 +30,7 @@ using StreamStart = SharpYaml.Events.StreamStart;
 
 namespace SharpYaml.Model {
     public abstract class YamlNode {
-        public YamlNodeTracker Tracker { get; internal set; }
+        public virtual YamlNodeTracker Tracker { get; internal set; }
 
         protected static YamlElement ReadElement(EventReader eventReader, YamlNodeTracker tracker = null) {
             if (eventReader.Accept<MappingStart>())

--- a/SharpYaml/Model/YamlSequence.cs
+++ b/SharpYaml/Model/YamlSequence.cs
@@ -160,6 +160,9 @@ namespace SharpYaml.Model
         public override YamlNodeTracker Tracker {
             get { return base.Tracker; }
             internal set {
+                if (Tracker == value)
+                    return;
+
                 base.Tracker = value;
 
                 for (var index = 0; index < _contents.Count; index++) {

--- a/SharpYaml/Model/YamlSequence.cs
+++ b/SharpYaml/Model/YamlSequence.cs
@@ -37,22 +37,20 @@ namespace SharpYaml.Model
         }
 
         YamlSequence(SequenceStart sequenceStart, SequenceEnd sequenceEnd, List<YamlElement> contents, YamlNodeTracker tracker) {
-            Tracker = tracker;
-
-            this._sequenceStart = sequenceStart;
-
-            if (Tracker != null)
-                Tracker.OnSequenceStartChanged(this, null, sequenceStart);
-
-            this._sequenceEnd = sequenceEnd;
-
-            if (Tracker == null)
+            if (tracker == null)
                 _contents = contents;
             else {
                 _contents = new List<YamlElement>();
+
+                Tracker = tracker;
+
                 foreach (var item in contents)
                     Add(item);
             }
+
+            SequenceStart = sequenceStart;
+            
+            this._sequenceEnd = sequenceEnd;
         }
 
         public SequenceStart SequenceStart {
@@ -156,6 +154,19 @@ namespace SharpYaml.Model
             if (Tracker != null) {
                 item.Tracker = Tracker;
                 Tracker.OnSequenceAddElement(this, item, _contents.Count - 1);
+            }
+        }
+
+        public override YamlNodeTracker Tracker {
+            get { return base.Tracker; }
+            internal set {
+                base.Tracker = value;
+
+                for (var index = 0; index < _contents.Count; index++) {
+                    var item = _contents[index];
+                    item.Tracker = value;
+                    Tracker.OnSequenceAddElement(this, item, index);
+                }
             }
         }
 

--- a/SharpYaml/Model/YamlStream.cs
+++ b/SharpYaml/Model/YamlStream.cs
@@ -103,6 +103,9 @@ namespace SharpYaml.Model
         public override YamlNodeTracker Tracker {
             get { return base.Tracker; }
             internal set {
+                if (Tracker == value)
+                    return;
+
                 base.Tracker = value;
 
                 for (var index = 0; index < _documents.Count; index++) {

--- a/SharpYaml/Model/YamlStream.cs
+++ b/SharpYaml/Model/YamlStream.cs
@@ -39,15 +39,16 @@ namespace SharpYaml.Model
         }
 
         YamlStream(StreamStart streamStart, StreamEnd streamEnd, List<YamlDocument> documents, YamlNodeTracker tracker = null) {
-            Tracker = tracker;
-
             this._streamStart = streamStart;
             this._streamEnd = streamEnd;
 
-            if (Tracker == null)
+            if (tracker == null)
                 _documents = documents;
             else {
                 _documents = new List<YamlDocument>();
+
+                Tracker = tracker;
+
                 foreach (var document in documents)
                     Add(document);
             }
@@ -96,6 +97,19 @@ namespace SharpYaml.Model
             if (Tracker != null) {
                 item.Tracker = Tracker;
                 Tracker.OnStreamAddDocument(this, item, _documents.Count - 1);
+            }
+        }
+        
+        public override YamlNodeTracker Tracker {
+            get { return base.Tracker; }
+            internal set {
+                base.Tracker = value;
+
+                for (var index = 0; index < _documents.Count; index++) {
+                    var item = _documents[index];
+                    item.Tracker = value;
+                    Tracker.OnStreamAddDocument(this, item, index);
+                }
             }
         }
 


### PR DESCRIPTION
I was running into an issue when I would add a node with children to a document, and the children would not get tracked while the main node was.