### PR TITLE
ChildIndex.Resolve avoids OutOfRangeExceptions, returns null instead.

### DIFF
--- a/SharpYaml/Model/YamlNodeTracker.cs
+++ b/SharpYaml/Model/YamlNodeTracker.cs
@@ -19,6 +19,8 @@ namespace SharpYaml.Model {
             if (stream != null) {
                 if (IsKey)
                     return null;
+                if (Index < 0 || Index >= stream.Count)
+                    return null;
                 return stream[Index];
             }
 
@@ -33,12 +35,15 @@ namespace SharpYaml.Model {
             if (sequence != null) {
                 if (IsKey)
                     return null;
-
+                if (Index < 0 || Index >= sequence.Count)
+                    return null;
                 return sequence[Index];
             }
 
             var mapping = parent as YamlMapping;
             if (mapping != null) {
+                if (Index < 0 || Index >= mapping.Count)
+                    return null;
                 return IsKey
                     ? mapping[Index].Key
                     : mapping[Index].Value;


### PR DESCRIPTION
Path.Resolve() is intended to function as a way to check if the given path is still valid when the data has changed, but I wasn't checking that the indices were still in range, so it was throwing exceptions.