### PR TITLE
enable SourceLink

### DIFF
--- a/SharpYaml/Directory.Build.props
+++ b/SharpYaml/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+  <PropertyGroup>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All"/>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This enabled SourceLink support the Microsoft new high performance version here:
https://github.com/dotnet/sourcelink/


I validated that it works with:
```
PS C:\Users\taggac\sourcelink\SourceLink\build> dotnet sourcelink test "C:\Users\taggac\sourcelink\SharpYaml\SharpYaml\bin\Release\SharpYaml.1.6.3.nupkg"
sourcelink test passed: lib/net35/SharpYaml.pdb
sourcelink test passed: lib/net45/SharpYaml.pdb
sourcelink test passed: lib/netstandard1.3/SharpYaml.pdb
sourcelink test passed: lib/netstandard1.6/SharpYaml.pdb
sourcelink test passed: lib/portable40-net40+sl5+win8+wp8+wpa81/SharpYaml.pdb
```