### PR TITLE
Make CoreSchema a singleton so that PrepareScalarRules only runs once.

### DIFF
--- a/SharpYaml/Schemas/CoreSchema.cs
+++ b/SharpYaml/Schemas/CoreSchema.cs
@@ -58,11 +58,7 @@ namespace SharpYaml.Schemas
     /// </remarks>
     public class CoreSchema : JsonSchema
     {
-        public static CoreSchema Instance { get; }
-
-        static CoreSchema() {
-            Instance = new CoreSchema();
-        }
+        public static readonly CoreSchema Instance = new CoreSchema();
 
         protected override void PrepareScalarRules()
         {

--- a/SharpYaml/Schemas/CoreSchema.cs
+++ b/SharpYaml/Schemas/CoreSchema.cs
@@ -58,6 +58,12 @@ namespace SharpYaml.Schemas
     /// </remarks>
     public class CoreSchema : JsonSchema
     {
+        public static CoreSchema Instance { get; }
+
+        static CoreSchema() {
+            Instance = new CoreSchema();
+        }
+
         protected override void PrepareScalarRules()
         {
             // 10.2.1.1. Null

--- a/SharpYaml/Serialization/SerializerSettings.cs
+++ b/SharpYaml/Serialization/SerializerSettings.cs
@@ -89,7 +89,7 @@ namespace SharpYaml.Serialization
             SpecialCollectionMember = "~Items";
             LimitPrimitiveFlowSequence = 0;
             DefaultStyle = YamlStyle.Block;
-            this.schema = schema ?? new CoreSchema();
+            this.schema = schema ?? CoreSchema.Instance;
             AssemblyRegistry = new AssemblyRegistry(Schema);
             attributeRegistry = new AttributeRegistry();
             ObjectFactory = new DefaultObjectFactory();


### PR DESCRIPTION
I ran into a performance problem because I was deserializing individual leaf nodes of a YAML file using `YamlNode.ToObject`, and so I was creating a new `SerializerSettings` every time. As a result, `PrepareScalarRules` in `CoreSchema` ran over and over and was a big performance hit. This solves that problem.