### PR TITLE
Always enclose keys in quotes when emitting JSON.

### DIFF
--- a/src/SharpYaml.Tests/Serialization/SerializationTests.cs
+++ b/src/SharpYaml.Tests/Serialization/SerializationTests.cs
@@ -505,6 +505,25 @@ namespace SharpYaml.Tests.Serialization
         }
 
         [Test]
+        public void JsonKeysAreQuoted() {
+            var settings = new SerializerSettings() { EmitDefaultValues = true, EmitJsonComptible = true, EmitTags = false };
+            var serializer = new Serializer(settings);
+
+            var buffer = new StringWriter();
+            
+            serializer.Serialize(buffer, new Dictionary<int, int> {{ 5, 10 } });
+
+            Dump.WriteLine(buffer);
+            var bufferText = buffer.ToString();
+            Assert.AreEqual("{\"5\": 10}", bufferText.Trim());
+
+            var dict = serializer.Deserialize<Dictionary<int, int>>(bufferText);
+            Assert.AreEqual(1, dict.Count);
+            Assert.AreEqual(5, dict.First().Key);
+            Assert.AreEqual(10, dict.First().Value);
+        }
+
+        [Test]
         public void DeserializationOfNullWorksInJson()
         {
             var settings = new SerializerSettings() {EmitDefaultValues = true, EmitJsonComptible = true};

--- a/src/SharpYaml/Emitter.cs
+++ b/src/SharpYaml/Emitter.cs
@@ -83,6 +83,7 @@ namespace SharpYaml
         private bool isWhitespace;
         private bool isIndentation;
         private bool forceIndentLess;
+        private bool emitKeyQuoted;
 
         private bool isOpenEnded;
 
@@ -128,12 +129,13 @@ namespace SharpYaml
         /// <param name="bestWidth">The preferred text width.</param>
         /// <param name="isCanonical">If true, write the output in canonical form.</param>
         /// <param name="forceIndentLess">if set to <c>true</c> [always indent].</param>
+        /// <param name="emitKeyQuoted">if set to <c>true</c> always emit keys double quoted.</param>
         /// <exception cref="System.ArgumentOutOfRangeException">
         /// bestIndent
         /// or
         /// bestWidth;The bestWidth parameter must be greater than bestIndent * 2.
         /// </exception>
-        public Emitter(TextWriter output, int bestIndent = MinBestIndent, int bestWidth = int.MaxValue, bool isCanonical = false, bool forceIndentLess = false)
+        public Emitter(TextWriter output, int bestIndent = MinBestIndent, int bestWidth = int.MaxValue, bool isCanonical = false, bool forceIndentLess = false, bool emitKeyQuoted = false)
         {
             if (bestIndent < MinBestIndent || bestIndent > MaxBestIndent)
             {
@@ -151,6 +153,7 @@ namespace SharpYaml
 
             this.isCanonical = isCanonical;
             this.forceIndentLess = forceIndentLess;
+            this.emitKeyQuoted = emitKeyQuoted;
 
             this.output = output;
             this.isUnicode = output.Encoding.WebName.StartsWith("utf", StringComparison.OrdinalIgnoreCase);
@@ -1447,7 +1450,7 @@ namespace SharpYaml
                 style = ScalarStyle.DoubleQuoted;
             }
 
-            if (isSimpleKeyContext && scalarData.isMultiline)
+            if (isSimpleKeyContext && (scalarData.isMultiline || emitKeyQuoted))
             {
                 style = ScalarStyle.DoubleQuoted;
             }

--- a/src/SharpYaml/Serialization/Serializer.cs
+++ b/src/SharpYaml/Serialization/Serializer.cs
@@ -165,7 +165,7 @@ namespace SharpYaml.Serialization
         /// <param name="graph">The object to serialize.</param>
         public void Serialize(TextWriter writer, object graph)
         {
-            Serialize(new Emitter(writer, Settings.PreferredIndent), graph);
+            Serialize(new Emitter(writer, Settings.PreferredIndent, emitKeyQuoted:Settings.EmitJsonComptible), graph);
         }
 
         /// <summary>
@@ -177,7 +177,7 @@ namespace SharpYaml.Serialization
         /// <param name="contextSettings">The context settings.</param>
         public void Serialize(TextWriter writer, object graph, Type type, SerializerContextSettings contextSettings = null)
         {
-            Serialize(new Emitter(writer, Settings.PreferredIndent), graph, type, contextSettings);
+            Serialize(new Emitter(writer, Settings.PreferredIndent, emitKeyQuoted: Settings.EmitJsonComptible), graph, type, contextSettings);
         }
 
         /// <summary>


### PR DESCRIPTION
Not sure what to do for the case of complex keys, but they're probably not valid JSON anyway.