### PR TITLE
When an item is inserted/removed from a container, update the indices of the subsequent children in the tracker.

### DIFF
--- a/src/SharpYaml.Tests/PathTrieTest.cs
+++ b/src/SharpYaml.Tests/PathTrieTest.cs
@@ -1,0 +1,69 @@
+﻿using System.Linq;
+using NUnit.Framework;
+using SharpYaml.Model;
+using Path = SharpYaml.Model.Path;
+using YamlStream = SharpYaml.Model.YamlStream;
+
+namespace SharpYaml.Tests {
+    public class PathTrieTest {
+        [Test]
+        public void BasicTest() {
+            var trie = new PathTrie();
+            var root = new YamlStream();
+            var path = new Path(root, new[] {
+                new ChildIndex(0, false),
+                new ChildIndex(-1, false),
+                new ChildIndex(2, false)
+            });
+            
+            trie.Add(path);
+            
+            Assert.IsTrue(trie.Contains(path, false));
+            Assert.IsTrue(trie.Contains(path, true));
+            
+            Assert.IsFalse(trie.Contains(path.GetParentPath().Value, false));
+            Assert.IsTrue(trie.Contains(path.GetParentPath().Value, true));
+
+            var childPath = path.Clone();
+            childPath.Append(new ChildIndex(1, false));
+
+            Assert.IsFalse(trie.Contains(childPath, false));
+            Assert.IsFalse(trie.Contains(childPath, true));
+
+            var subPaths = trie.GetSubpaths(path).ToList();
+            
+            Assert.AreEqual(1, subPaths.Count);
+            Assert.AreEqual(path, subPaths[0]);
+            
+            trie.Add(childPath);
+
+            Assert.IsTrue(trie.Contains(childPath, false));
+            Assert.IsTrue(trie.Contains(childPath, true));
+
+            subPaths = trie.GetSubpaths(path).ToList();
+
+            Assert.AreEqual(2, subPaths.Count);
+            Assert.AreEqual(path, subPaths[0]);
+            Assert.AreEqual(childPath, subPaths[1]);
+
+            var result = trie.Remove(path.GetParentPath().Value, false);
+            Assert.IsFalse(result);
+            Assert.IsTrue(trie.Contains(path, false));
+            Assert.IsTrue(trie.Contains(childPath, false));
+
+            result = trie.Remove(path, false);
+            Assert.IsTrue(result);
+            Assert.IsFalse(trie.Contains(path, false));
+            Assert.IsTrue(trie.Contains(path, true));
+            Assert.IsTrue(trie.Contains(childPath, false));
+            
+            trie.Add(path);
+
+            result = trie.Remove(path, true);
+            Assert.IsTrue(result);
+            Assert.IsFalse(trie.Contains(path, false));
+            Assert.IsFalse(trie.Contains(path, true));
+            Assert.IsFalse(trie.Contains(childPath, false));
+        }
+    }
+}

--- a/src/SharpYaml/Model/PathTrie.cs
+++ b/src/SharpYaml/Model/PathTrie.cs
@@ -1,0 +1,132 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace SharpYaml.Model {
+    public class PathTrie {
+        class PathTrieNode {
+            public bool Self { get; private set; }
+            readonly Dictionary<ChildIndex, PathTrieNode> subPaths = new Dictionary<ChildIndex, PathTrieNode>();
+
+            public void Add(IList<ChildIndex> indices, int start) {
+                if (start == indices.Count) {
+                    Self = true;
+                    return;
+                }
+
+                PathTrieNode subPath;
+                if (!subPaths.TryGetValue(indices[start], out subPath)) {
+                    subPath = new PathTrieNode();
+                    subPaths[indices[start]] = subPath;
+                }
+
+                subPath.Add(indices, start + 1);
+            }
+
+            public bool Remove(IList<ChildIndex> indices, int start, bool removeChildren) {
+                if (start == indices.Count) {
+                    var result = Self || (removeChildren && subPaths.Count > 0);
+                    
+                    Self = false;
+
+                    if (removeChildren)
+                        subPaths.Clear();
+
+                    return result;
+                }
+
+                PathTrieNode subPath;
+                if (!subPaths.TryGetValue(indices[start], out subPath))
+                    return false;
+
+                if (!subPath.Remove(indices, start + 1, removeChildren))
+                    return false;
+
+                if (subPath.IsEmpty)
+                    subPaths.Remove(indices[start]);
+
+                return true;
+            }
+
+            public bool IsEmpty {
+                get { return !Self && subPaths.Count == 0; }
+            }
+
+            public PathTrieNode Find(IList<ChildIndex> indices, int start) {
+                if (start == indices.Count)
+                    return this;
+
+                PathTrieNode subPath;
+                if (!subPaths.TryGetValue(indices[start], out subPath))
+                    return null;
+
+                return subPath.Find(indices, start + 1);
+            }
+
+            public IEnumerable<List<ChildIndex>> GetReversePaths() {
+                if (Self)
+                    yield return new List<ChildIndex>();
+
+                foreach (var pair in subPaths) {
+                    foreach (var path in pair.Value.GetReversePaths()) {
+                        path.Add(pair.Key);
+                        yield return path;
+                    }
+                }
+            }
+        }
+
+        private readonly Dictionary<YamlNode, PathTrieNode> roots = new Dictionary<YamlNode, PathTrieNode>();
+
+        public void Add(Path path) {
+            PathTrieNode root;
+            if (!roots.TryGetValue(path.Root, out root)) {
+                root = new PathTrieNode();
+                roots[path.Root] = root;
+            }
+
+            root.Add(path.Indices, 0);
+        }
+
+        public bool Remove(Path path, bool removeChildren) {
+            PathTrieNode root;
+            if (!roots.TryGetValue(path.Root, out root))
+                return false;
+
+            if (!root.Remove(path.Indices, 0, removeChildren))
+                return false;
+
+            if (root.IsEmpty)
+                roots.Remove(path.Root);
+
+            return true;
+        }
+
+        public bool Contains(Path path, bool orChildren) {
+            PathTrieNode root;
+            if (!roots.TryGetValue(path.Root, out root))
+                return false;
+
+            var node = root.Find(path.Indices, 0);
+            if (node == null)
+                return false;
+
+            return node.Self || orChildren;
+        }
+
+        public IEnumerable<Path> GetSubpaths(Path path) {
+            PathTrieNode root;
+            if (!roots.TryGetValue(path.Root, out root))
+                yield break;
+
+            var node = root.Find(path.Indices, 0);
+            if (node == null)
+                yield break;
+
+            foreach (var reversePath in node.GetReversePaths()) {
+                reversePath.AddRange(path.Indices.Reverse());
+                reversePath.Reverse();
+                yield return new Path(path.Root, reversePath.ToArray());
+            }
+        }
+    }
+}

--- a/src/SharpYaml/Model/YamlMapping.cs
+++ b/src/SharpYaml/Model/YamlMapping.cs
@@ -148,7 +148,7 @@ namespace SharpYaml.Model {
         }
 
         public IEnumerator<KeyValuePair<YamlElement, YamlElement>> GetEnumerator() {
-            return _contents.GetEnumerator();
+            return _keys.Select(k => new KeyValuePair<YamlElement, YamlElement>(k, _contents[k])).GetEnumerator();
         }
 
         void ICollection<KeyValuePair<YamlElement, YamlElement>>.Add(KeyValuePair<YamlElement, YamlElement> item) {
@@ -165,7 +165,7 @@ namespace SharpYaml.Model {
 
             if (Tracker != null) {
                 for (int i = values.Count - 1; i >= 0; i--)
-                    Tracker.OnMappingRemovePair(this, values[i], i);
+                    Tracker.OnMappingRemovePair(this, values[i], i, null);
             }
         }
 
@@ -196,7 +196,7 @@ namespace SharpYaml.Model {
                 key.Tracker = Tracker;
                 value.Tracker = Tracker;
 
-                Tracker.OnMappingAddPair(this, new KeyValuePair<YamlElement, YamlElement>(key, value), _keys.Count - 1);
+                Tracker.OnMappingAddPair(this, new KeyValuePair<YamlElement, YamlElement>(key, value), _keys.Count - 1, null);
             }
         }
 
@@ -214,7 +214,7 @@ namespace SharpYaml.Model {
                     _keys[i].Tracker = value;
                     val.Tracker = value;
 
-                    Tracker.OnMappingAddPair(this, new KeyValuePair<YamlElement, YamlElement>(_keys[i], val), i);
+                    Tracker.OnMappingAddPair(this, new KeyValuePair<YamlElement, YamlElement>(_keys[i], val), i, null);
                 }
             }
         }
@@ -307,7 +307,7 @@ namespace SharpYaml.Model {
                         key.Tracker = Tracker;
                         value.Tracker = Tracker;
                         Tracker.OnMappingAddPair(this, new KeyValuePair<YamlElement, YamlElement>(key, value),
-                            _keys.Count - 1);
+                            _keys.Count - 1, null);
                     }
                     else {
                         value.Tracker = Tracker;
@@ -361,7 +361,12 @@ namespace SharpYaml.Model {
             if (Tracker != null) {
                 item.Key.Tracker = Tracker;
                 item.Value.Tracker = Tracker;
-                Tracker.OnMappingAddPair(this, item, index);
+
+                IEnumerable<KeyValuePair<YamlElement, YamlElement>> nextChildren = null;
+                if (index < _contents.Count - 1)
+                    nextChildren = this.Skip(index + 1);
+                
+                Tracker.OnMappingAddPair(this, item, index, nextChildren);
             }
         }
 
@@ -376,8 +381,13 @@ namespace SharpYaml.Model {
                 stringKeys.Remove(((YamlValue) key).Value);
             }
 
-            if (Tracker != null)
-                Tracker.OnMappingRemovePair(this, new KeyValuePair<YamlElement, YamlElement>(key, value), index);
+            if (Tracker != null) {
+                IEnumerable<KeyValuePair<YamlElement, YamlElement>> nextChildren = null;
+                if (index < _contents.Count)
+                    nextChildren = this.Skip(index);
+
+                Tracker.OnMappingRemovePair(this, new KeyValuePair<YamlElement, YamlElement>(key, value), index, nextChildren);
+            }
         }
 
         public KeyValuePair<YamlElement, YamlElement> this[int index] {

--- a/src/SharpYaml/Model/YamlMapping.cs
+++ b/src/SharpYaml/Model/YamlMapping.cs
@@ -362,9 +362,9 @@ namespace SharpYaml.Model {
                 item.Key.Tracker = Tracker;
                 item.Value.Tracker = Tracker;
 
-                IEnumerable<KeyValuePair<YamlElement, YamlElement>> nextChildren = null;
+                ICollection<KeyValuePair<YamlElement, YamlElement>> nextChildren = null;
                 if (index < _contents.Count - 1)
-                    nextChildren = this.Skip(index + 1);
+                    nextChildren = this.Skip(index + 1).ToArray();
                 
                 Tracker.OnMappingAddPair(this, item, index, nextChildren);
             }

--- a/src/SharpYaml/Model/YamlNodeTracker.cs
+++ b/src/SharpYaml/Model/YamlNodeTracker.cs
@@ -418,7 +418,7 @@ namespace SharpYaml.Model {
         }
 
         void ShiftChild(YamlNode child, YamlNode parent, ChildIndex relationship, int shift) {
-            HashSet<ParentAndIndex> set;
+            ICollection<ParentAndIndex> set;
             if (!parents.TryGetValue(child, out set))
                 return;
 
@@ -448,8 +448,13 @@ namespace SharpYaml.Model {
                 }
             }
 
-            set.Remove(new ParentAndIndex(parent, relationship));
-            set.Add(new ParentAndIndex(parent, newChildIndex));
+            var array = set as ParentAndIndex[];
+            if (array != null) {
+                array[0] = new ParentAndIndex(parent, newChildIndex);
+            } else {
+                set.Remove(new ParentAndIndex(parent, relationship));
+                set.Add(new ParentAndIndex(parent, newChildIndex));
+            }
         }
 
         public IList<Path> GetPaths(YamlNode child) {

--- a/src/SharpYaml/Model/YamlNodeTracker.cs
+++ b/src/SharpYaml/Model/YamlNodeTracker.cs
@@ -122,7 +122,7 @@ namespace SharpYaml.Model {
             return new Path(Root, Indices.Take(Indices.Length - 1).ToArray());
         }
     }
-
+    
     public enum TrackerEventType {
         StreamDocumentAdded,
         StreamDocumentRemoved,
@@ -409,7 +409,11 @@ namespace SharpYaml.Model {
                 var childPath = parentPath.Clone();
                 childPath.Append(childIndex);
 
-                subscribers.Remove(childPath);
+                foreach (var subpath in pathTrie.GetSubpaths(childPath)) {
+                    subscribers.Remove(subpath);
+                }
+
+                pathTrie.Remove(childPath, true);
             }
         }
 
@@ -424,15 +428,23 @@ namespace SharpYaml.Model {
                 var oldPaths = GetPaths(child);
 
                 foreach (var oldPath in oldPaths) {
-                    Dictionary<WeakReference, string> subs;
-                    if (!subscribers.TryGetValue(oldPath, out subs))
-                        continue;
+                    var newPaths = new List<Path>();
+                    foreach (var subpath in pathTrie.GetSubpaths(oldPath)) {
+                        Dictionary<WeakReference, string> subs;
+                        if (!subscribers.TryGetValue(subpath, out subs))
+                            continue;
 
-                    var newPath = oldPath.Clone();
-                    newPath.Indices[newPath.Indices.Length - 1] = newChildIndex;
+                        var newPath = subpath.Clone();
+                        newPath.Indices[oldPath.Indices.Length - 1] = newChildIndex;
 
-                    subscribers.Remove(oldPath);
-                    subscribers[newPath] = subs;
+                        subscribers.Remove(oldPath);
+                        subscribers[newPath] = subs;
+                        newPaths.Add(newPath);
+                    }
+
+                    pathTrie.Remove(oldPath, true);
+                    foreach (var newPath in newPaths)
+                        pathTrie.Add(newPath);
                 }
             }
 
@@ -712,6 +724,7 @@ namespace SharpYaml.Model {
 
         private Dictionary<Path, Dictionary<WeakReference, string>> subscribers;
         private Dictionary<WeakReference, string> noFilterSubscribers;
+        private PathTrie pathTrie;
 
         void CompactSubscribers() {
             foreach (var path in subscribers.Keys.ToArray()) {
@@ -722,8 +735,10 @@ namespace SharpYaml.Model {
                         dict.Remove(key);
                 }
 
-                if (dict.Count == 0)
+                if (dict.Count == 0) {
                     subscribers.Remove(path);
+                    pathTrie.Remove(path, false);
+                }
             }
 
             foreach (var key in noFilterSubscribers.Keys.ToArray()) {
@@ -736,6 +751,7 @@ namespace SharpYaml.Model {
             if (subscribers == null) {
                 subscribers = new Dictionary<Path, Dictionary<WeakReference, string>>();
                 noFilterSubscribers = new Dictionary<WeakReference, string>();
+                pathTrie = new PathTrie();
             }
 
             CompactSubscribers();
@@ -745,6 +761,7 @@ namespace SharpYaml.Model {
                 if (!subscribers.TryGetValue(filterPath.Value, out dict)) {
                     dict = new Dictionary<WeakReference, string>();
                     subscribers[filterPath.Value] = dict;
+                    pathTrie.Add(filterPath.Value);
                 }
             }
             else

--- a/src/SharpYaml/Model/YamlSequence.cs
+++ b/src/SharpYaml/Model/YamlSequence.cs
@@ -206,9 +206,9 @@ namespace SharpYaml.Model
             if (Tracker != null) {
                 item.Tracker = Tracker;
 
-                IEnumerable<YamlElement> nextChildren = null;
+                ICollection<YamlElement> nextChildren = null;
                 if (index < _contents.Count - 1)
-                    nextChildren = _contents.Skip(index + 1);
+                    nextChildren = _contents.Skip(index + 1).ToArray();
                 
                 Tracker.OnSequenceAddElement(this, item, index, nextChildren);
             }

--- a/src/SharpYaml/Model/YamlSequence.cs
+++ b/src/SharpYaml/Model/YamlSequence.cs
@@ -143,7 +143,7 @@ namespace SharpYaml.Model
 
             if (Tracker != null) {
                 item.Tracker = Tracker;
-                Tracker.OnSequenceAddElement(this, item, _contents.Count - 1);
+                Tracker.OnSequenceAddElement(this, item, _contents.Count - 1, null);
             }
         }
 
@@ -158,7 +158,7 @@ namespace SharpYaml.Model
                 for (var index = 0; index < _contents.Count; index++) {
                     var item = _contents[index];
                     item.Tracker = value;
-                    Tracker.OnSequenceAddElement(this, item, index);
+                    Tracker.OnSequenceAddElement(this, item, index, null);
                 }
             }
         }
@@ -170,7 +170,7 @@ namespace SharpYaml.Model
 
             if (Tracker != null) {
                 for (int i = copy.Count - 1; i >= 0; i--)
-                    Tracker.OnSequenceRemoveElement(this, copy[i], i);
+                    Tracker.OnSequenceRemoveElement(this, copy[i], i, null);
             }
         }
 
@@ -205,7 +205,12 @@ namespace SharpYaml.Model
 
             if (Tracker != null) {
                 item.Tracker = Tracker;
-                Tracker.OnSequenceAddElement(this, item, index);
+
+                IEnumerable<YamlElement> nextChildren = null;
+                if (index < _contents.Count - 1)
+                    nextChildren = _contents.Skip(index + 1);
+                
+                Tracker.OnSequenceAddElement(this, item, index, nextChildren);
             }
         }
 
@@ -214,8 +219,13 @@ namespace SharpYaml.Model
 
             _contents.RemoveAt(index);
 
-            if (Tracker != null)
-                Tracker.OnSequenceRemoveElement(this, oldValue, index);
+            if (Tracker != null) {
+                IEnumerable<YamlElement> nextChildren = null;
+                if (index < _contents.Count)
+                    nextChildren = _contents.Skip(index);
+                
+                Tracker.OnSequenceRemoveElement(this, oldValue, index, nextChildren);
+            }
         }
 
         public YamlElement this[int index] {

--- a/src/SharpYaml/Model/YamlStream.cs
+++ b/src/SharpYaml/Model/YamlStream.cs
@@ -85,7 +85,7 @@ namespace SharpYaml.Model {
 
             if (Tracker != null) {
                 item.Tracker = Tracker;
-                Tracker.OnStreamAddDocument(this, item, _documents.Count - 1);
+                Tracker.OnStreamAddDocument(this, item, _documents.Count - 1, null);
             }
         }
 
@@ -100,7 +100,7 @@ namespace SharpYaml.Model {
                 for (var index = 0; index < _documents.Count; index++) {
                     var item = _documents[index];
                     item.Tracker = value;
-                    Tracker.OnStreamAddDocument(this, item, index);
+                    Tracker.OnStreamAddDocument(this, item, index, null);
                 }
             }
         }
@@ -112,7 +112,7 @@ namespace SharpYaml.Model {
 
             if (Tracker != null) {
                 for (int i = copy.Count; i >= 0; i--)
-                    Tracker.OnStreamRemoveDocument(this, copy[i], i);
+                    Tracker.OnStreamRemoveDocument(this, copy[i], i, null);
             }
         }
 
@@ -147,7 +147,12 @@ namespace SharpYaml.Model {
 
             if (Tracker != null) {
                 item.Tracker = Tracker;
-                Tracker.OnStreamAddDocument(this, item, index);
+
+                IEnumerable<YamlDocument> nextDocuments = null;
+                if (index < _documents.Count - 1)
+                    nextDocuments = _documents.Skip(index + 1);
+                
+                Tracker.OnStreamAddDocument(this, item, index, nextDocuments);
             }
         }
 
@@ -156,8 +161,13 @@ namespace SharpYaml.Model {
 
             _documents.RemoveAt(index);
 
-            if (Tracker != null)
-                Tracker.OnStreamRemoveDocument(this, oldValue, index);
+            if (Tracker != null) {
+                IEnumerable<YamlDocument> nextDocuments = null;
+                if (index < _documents.Count)
+                    nextDocuments = _documents.Skip(index);
+                
+                Tracker.OnStreamRemoveDocument(this, oldValue, index, nextDocuments);
+            }
         }
 
         public YamlDocument this[int index] {

--- a/src/SharpYaml/Model/YamlStream.cs
+++ b/src/SharpYaml/Model/YamlStream.cs
@@ -148,9 +148,9 @@ namespace SharpYaml.Model {
             if (Tracker != null) {
                 item.Tracker = Tracker;
 
-                IEnumerable<YamlDocument> nextDocuments = null;
+                ICollection<YamlDocument> nextDocuments = null;
                 if (index < _documents.Count - 1)
-                    nextDocuments = _documents.Skip(index + 1);
+                    nextDocuments = _documents.Skip(index + 1).ToArray();
                 
                 Tracker.OnStreamAddDocument(this, item, index, nextDocuments);
             }


### PR DESCRIPTION
This is a bug that took me a while to diagnose. After modifying a container, the modification events were giving me incorrect paths to the item which was modified.

Also fixed YamlMapping's enumerator to return items in the same order as the keys.