### PR TITLE
Use StringLookaheadBuffer if a string is available.

### DIFF
--- a/src/SharpYaml.Tests/EmitterTests.cs
+++ b/src/SharpYaml.Tests/EmitterTests.cs
@@ -183,7 +183,7 @@ namespace SharpYaml.Tests
             var testText = YamlFile(name).ReadToEnd();
 
             var output = new StringWriter();
-            IParser parser = new Parser(new StringReader(testText));
+            IParser parser = Parser.CreateParser(new StringReader(testText));
             IEmitter emitter = new Emitter(output, 2, int.MaxValue, false);
             Dump.WriteLine("= Parse and emit yaml file [" + name + "] =");
             while (parser.MoveNext())

--- a/src/SharpYaml.Tests/ParserTests.cs
+++ b/src/SharpYaml.Tests/ParserTests.cs
@@ -333,7 +333,7 @@ namespace SharpYaml.Tests
 
         private IParser ParserFor(string name)
         {
-            return new Parser(YamlFile(name));
+            return Parser.CreateParser(YamlFile(name));
         }
 
         private void AssertSequenceOfEventsFrom(IParser parser, params ParsingEvent[] events)

--- a/src/SharpYaml.Tests/ScannerTests.cs
+++ b/src/SharpYaml.Tests/ScannerTests.cs
@@ -74,7 +74,7 @@ namespace SharpYaml.Tests
         [Test]
         public void VerifyTokensOnExample3()
         {
-            Scanner scanner = ScannerFor("test3.yaml");
+            var scanner = ScannerFor("test3.yaml");
             AssertSequenceOfTokensFrom(scanner,
                 StreamStart,
                 DocumentStart,
@@ -352,12 +352,12 @@ namespace SharpYaml.Tests
                 StreamEnd);
         }
 
-        private Scanner ScannerFor(string name)
+        private Scanner<LookAheadBuffer> ScannerFor(string name)
         {
-            return new Scanner(YamlFile(name));
+            return new Scanner<LookAheadBuffer>(new LookAheadBuffer(YamlFile(name), Scanner<LookAheadBuffer>.MaxBufferLength));
         }
 
-        private void AssertSequenceOfTokensFrom(Scanner scanner, params Token[] tokens)
+        private void AssertSequenceOfTokensFrom(Scanner<LookAheadBuffer> scanner, params Token[] tokens)
         {
             var tokenNumber = 1;
             foreach (var expected in tokens)

--- a/src/SharpYaml.Tests/Serialization/SerializationTests.cs
+++ b/src/SharpYaml.Tests/Serialization/SerializationTests.cs
@@ -730,7 +730,7 @@ Name: Andy
 Name: Brad
 ...";
             var serializer = new Serializer();
-            var reader = new EventReader(new Parser(new StringReader(yaml)));
+            var reader = new EventReader(Parser.CreateParser(new StringReader(yaml)));
 
             reader.Expect<StreamStart>();
 
@@ -754,7 +754,7 @@ Name: Brad
 Name: Charles
 ...";
             var serializer = new Serializer();
-            var reader = new EventReader(new Parser(new StringReader(yaml)));
+            var reader = new EventReader(Parser.CreateParser(new StringReader(yaml)));
 
             reader.Allow<StreamStart>();
 

--- a/src/SharpYaml/CharacterAnalyzer.cs
+++ b/src/SharpYaml/CharacterAnalyzer.cs
@@ -48,34 +48,13 @@ using System.Diagnostics;
 
 namespace SharpYaml
 {
-    internal class CharacterAnalyzer<TBuffer> where TBuffer : ILookAheadBuffer
+    internal static class CharacterAnalyzer
     {
-        private readonly TBuffer buffer;
-
-        public CharacterAnalyzer(TBuffer buffer)
-        {
-            this.buffer = buffer;
-        }
-
-        public TBuffer Buffer { get { return buffer; } }
-
-        public bool EndOfInput { get { return buffer.EndOfInput; } }
-
-        public char Peek(int offset)
-        {
-            return buffer.Peek(offset);
-        }
-
-        public void Skip(int length)
-        {
-            buffer.Skip(length);
-        }
-
         /// <summary>
         /// Check if the character at the specified position is an alphabetical
         /// character, a digit, '_', or '-'.
         /// </summary>
-        public bool IsAlpha(int offset)
+        public static bool IsAlpha(ILookAheadBuffer buffer, int offset)
         {
             char character = buffer.Peek(offset);
             return
@@ -86,66 +65,66 @@ namespace SharpYaml
                 character == '-';
         }
 
-        public bool IsAlpha()
+        public static bool IsAlpha(this ILookAheadBuffer buffer)
         {
-            return IsAlpha(0);
+            return IsAlpha(buffer, 0);
         }
 
         /// <summary>
         /// Check if the character is ASCII.
         /// </summary>
-        public bool IsAscii(int offset)
+        public static bool IsAscii(this ILookAheadBuffer buffer, int offset)
         {
             return buffer.Peek(offset) <= '\x7F';
         }
 
-        public bool IsAscii()
+        public static bool IsAscii(this ILookAheadBuffer buffer)
         {
-            return IsAscii(0);
+            return IsAscii(buffer, 0);
         }
 
-        public bool IsPrintable(int offset)
+        public static bool IsPrintable(this ILookAheadBuffer buffer, int offset)
         {
             char character = buffer.Peek(offset);
             return Emitter.IsPrintable(character);
         }
 
-        public bool IsPrintable()
+        public static bool IsPrintable(this ILookAheadBuffer buffer)
         {
-            return IsPrintable(0);
+            return IsPrintable(buffer, 0);
         }
 
         /// <summary>
         /// Check if the character at the specified position is a digit.
         /// </summary>
-        public bool IsDigit(int offset)
+        public static bool IsDigit(this ILookAheadBuffer buffer, int offset)
         {
             char character = buffer.Peek(offset);
             return character >= '0' && character <= '9';
         }
 
-        public bool IsDigit()
+        public static bool IsDigit(this ILookAheadBuffer buffer)
         {
-            return IsDigit(0);
+            return IsDigit(buffer, 0);
         }
 
         /// <summary>
         /// Get the value of a digit.
         /// </summary>
-        public int AsDigit(int offset)
+        public static int AsDigit(this ILookAheadBuffer buffer, int offset)
         {
             return buffer.Peek(offset) - '0';
         }
 
-        public int AsDigit()
+        public static int AsDigit(this ILookAheadBuffer buffer)
         {
-            return AsDigit(0);
+            return AsDigit(buffer, 0);
         }
 
         /// <summary>
         /// Check if the character at the specified position is a hex-digit.
         /// </summary>
-        public bool IsHex(int offset)
+        public static bool IsHex(this ILookAheadBuffer buffer, int offset)
         {
             char character = buffer.Peek(offset);
             return
@@ -157,7 +136,7 @@ namespace SharpYaml
         /// <summary>
         /// Get the value of a hex-digit.
         /// </summary>
-        public int AsHex(int offset)
+        public static int AsHex(this ILookAheadBuffer buffer, int offset)
         {
             char character = buffer.Peek(offset);
 
@@ -175,120 +154,120 @@ namespace SharpYaml
             }
         }
 
-        public bool IsSpace(int offset)
+        public static bool IsSpace(this ILookAheadBuffer buffer, int offset)
         {
-            return Check(' ', offset);
+            return Check(buffer, ' ', offset);
         }
 
-        public bool IsSpace()
+        public static bool IsSpace(this ILookAheadBuffer buffer)
         {
-            return IsSpace(0);
+            return IsSpace(buffer, 0);
         }
 
         /// <summary>
         /// Check if the character at the specified position is NUL.
         /// </summary>
-        public bool IsZero(int offset)
+        public static bool IsZero(this ILookAheadBuffer buffer, int offset)
         {
-            return Check('\0', offset);
+            return Check(buffer, '\0', offset);
         }
 
-        public bool IsZero()
+        public static bool IsZero(this ILookAheadBuffer buffer)
         {
-            return IsZero(0);
+            return IsZero(buffer, 0);
         }
 
         /// <summary>
         /// Check if the character at the specified position is tab.
         /// </summary>
-        public bool IsTab(int offset)
+        public static bool IsTab(this ILookAheadBuffer buffer, int offset)
         {
-            return Check('\t', offset);
+            return Check(buffer, '\t', offset);
         }
 
-        public bool IsTab()
+        public static bool IsTab(this ILookAheadBuffer buffer)
         {
-            return IsTab(0);
+            return IsTab(buffer, 0);
         }
 
         /// <summary>
         /// Check if the character at the specified position is blank (space or tab).
         /// </summary>
-        public bool IsBlank(int offset)
+        public static bool IsBlank(this ILookAheadBuffer buffer, int offset)
         {
-            return IsSpace(offset) || IsTab(offset);
+            return IsSpace(buffer, offset) || IsTab(buffer, offset);
         }
 
-        public bool IsBlank()
+        public static bool IsBlank(this ILookAheadBuffer buffer)
         {
-            return IsBlank(0);
+            return IsBlank(buffer, 0);
         }
 
         /// <summary>
         /// Check if the character at the specified position is a line break.
         /// </summary>
-        public bool IsBreak(int offset)
+        public static bool IsBreak(this ILookAheadBuffer buffer, int offset)
         {
-            return Check("\r\n\x85\x2028\x2029", offset);
+            return Check(buffer, "\r\n\x85\x2028\x2029", offset);
         }
 
-        public bool IsBreak()
+        public static bool IsBreak(this ILookAheadBuffer buffer)
         {
-            return IsBreak(0);
+            return IsBreak(buffer, 0);
         }
 
-        public bool IsCrLf(int offset)
+        public static bool IsCrLf(this ILookAheadBuffer buffer, int offset)
         {
-            return Check('\r', offset) && Check('\n', offset + 1);
+            return Check(buffer, '\r', offset) && Check(buffer, '\n', offset + 1);
         }
 
-        public bool IsCrLf()
+        public static bool IsCrLf(this ILookAheadBuffer buffer)
         {
-            return IsCrLf(0);
+            return IsCrLf(buffer, 0);
         }
 
         /// <summary>
         /// Check if the character is a line break or NUL.
         /// </summary>
-        public bool IsBreakOrZero(int offset)
+        public static bool IsBreakOrZero(this ILookAheadBuffer buffer, int offset)
         {
-            return IsBreak(offset) || IsZero(offset);
+            return IsBreak(buffer, offset) || IsZero(buffer, offset);
         }
 
-        public bool IsBreakOrZero()
+        public static bool IsBreakOrZero(this ILookAheadBuffer buffer)
         {
-            return IsBreakOrZero(0);
+            return IsBreakOrZero(buffer, 0);
         }
 
         /// <summary>
         /// Check if the character is a line break, space, tab, or NUL.
         /// </summary>
-        public bool IsBlankOrBreakOrZero(int offset)
+        public static bool IsBlankOrBreakOrZero(this ILookAheadBuffer buffer, int offset)
         {
-            return IsBlank(offset) || IsBreakOrZero(offset);
+            return IsBlank(buffer, offset) || IsBreakOrZero(buffer, offset);
         }
 
-        public bool IsBlankOrBreakOrZero()
+        public static bool IsBlankOrBreakOrZero(this ILookAheadBuffer buffer)
         {
-            return IsBlankOrBreakOrZero(0);
+            return IsBlankOrBreakOrZero(buffer, 0);
         }
 
-        public bool Check(char expected)
+        public static bool Check(this ILookAheadBuffer buffer, char expected)
         {
-            return Check(expected, 0);
+            return Check(buffer, expected, 0);
         }
 
-        public bool Check(char expected, int offset)
+        public static bool Check(this ILookAheadBuffer buffer, char expected, int offset)
         {
             return buffer.Peek(offset) == expected;
         }
 
-        public bool Check(string expectedCharacters)
+        public static bool Check(this ILookAheadBuffer buffer, string expectedCharacters)
         {
-            return Check(expectedCharacters, 0);
+            return Check(buffer, expectedCharacters, 0);
         }
 
-        public bool Check(string expectedCharacters, int offset)
+        public static bool Check(this ILookAheadBuffer buffer, string expectedCharacters, int offset)
         {
             Debug.Assert(expectedCharacters.Length > 1, "Use Check(char, int) instead.");
 

--- a/src/SharpYaml/Emitter.cs
+++ b/src/SharpYaml/Emitter.cs
@@ -349,7 +349,7 @@ namespace SharpYaml
 
             bool preceeded_by_whitespace = true;
 
-            CharacterAnalyzer<StringLookAheadBuffer> buffer = new CharacterAnalyzer<StringLookAheadBuffer>(new StringLookAheadBuffer(value));
+            StringLookAheadBuffer buffer = new StringLookAheadBuffer(value);
             bool followed_by_whitespace = buffer.IsBlankOrBreakOrZero(1);
 
             // If the output is not detected as unicode, check if the value to encode contains 
@@ -433,7 +433,7 @@ namespace SharpYaml
                     {
                         leading_space = true;
                     }
-                    if (buffer.Buffer.Position >= buffer.Buffer.Length - 1)
+                    if (buffer.Position >= buffer.Length - 1)
                     {
                         trailing_space = true;
                     }
@@ -452,7 +452,7 @@ namespace SharpYaml
                     {
                         leading_break = true;
                     }
-                    if (buffer.Buffer.Position >= buffer.Buffer.Length - 1)
+                    if (buffer.Position >= buffer.Length - 1)
                     {
                         trailing_break = true;
                     }
@@ -1803,7 +1803,7 @@ namespace SharpYaml
 
         private void WriteBlockScalarHints(string value)
         {
-            var analyzer = new CharacterAnalyzer<StringLookAheadBuffer>(new StringLookAheadBuffer(value));
+            var analyzer = new StringLookAheadBuffer(value);
 
             if (analyzer.IsSpace() || analyzer.IsBreak())
             {

--- a/src/SharpYaml/Events/DocumentStart.cs
+++ b/src/SharpYaml/Events/DocumentStart.cs
@@ -52,7 +52,7 @@ namespace SharpYaml.Events
     /// <summary>
     /// Represents a document start event.
     /// </summary>
-    public class DocumentStart : ParsingEvent
+    public sealed class DocumentStart : ParsingEvent
     {
         /// <summary>
         /// Gets a value indicating the variation of depth caused by this event.

--- a/src/SharpYaml/Events/MappingStart.cs
+++ b/src/SharpYaml/Events/MappingStart.cs
@@ -51,7 +51,7 @@ namespace SharpYaml.Events
     /// <summary>
     /// Represents a mapping start event.
     /// </summary>
-    public class MappingStart : NodeEvent
+    public sealed class MappingStart : NodeEvent
     {
         /// <summary>
         /// Gets a value indicating the variation of depth caused by this event.

--- a/src/SharpYaml/Events/Scalar.cs
+++ b/src/SharpYaml/Events/Scalar.cs
@@ -51,7 +51,7 @@ namespace SharpYaml.Events
     /// <summary>
     /// Represents a scalar event.
     /// </summary>
-    public class Scalar : NodeEvent
+    public sealed class Scalar : NodeEvent
     {
         private string value;
 
@@ -71,7 +71,7 @@ namespace SharpYaml.Events
         /// Gets the value.
         /// </summary>
         /// <value>The value.</value>
-        public string Value { get { return value; } set { this.value = value; } }
+        public string Value { get { return value; } }
 
         private readonly ScalarStyle style;
 

--- a/src/SharpYaml/Events/SequenceStart.cs
+++ b/src/SharpYaml/Events/SequenceStart.cs
@@ -51,7 +51,7 @@ namespace SharpYaml.Events
     /// <summary>
     /// Represents a sequence start event.
     /// </summary>
-    public class SequenceStart : NodeEvent
+    public sealed class SequenceStart : NodeEvent
     {
         /// <summary>
         /// Gets a value indicating the variation of depth caused by this event.

--- a/src/SharpYaml/Events/StreamStart.cs
+++ b/src/SharpYaml/Events/StreamStart.cs
@@ -50,7 +50,7 @@ namespace SharpYaml.Events
     /// <summary>
     /// Represents a stream start event.
     /// </summary>
-    public class StreamStart : ParsingEvent
+    public sealed class StreamStart : ParsingEvent
     {
         /// <summary>
         /// Gets a value indicating the variation of depth caused by this event.

--- a/src/SharpYaml/ILookAheadBuffer.cs
+++ b/src/SharpYaml/ILookAheadBuffer.cs
@@ -47,7 +47,7 @@ using System;
 
 namespace SharpYaml
 {
-    internal interface ILookAheadBuffer
+    public interface ILookAheadBuffer
     {
         /// <summary>
         /// Gets a value indicating whether the end of the input reader has been reached.
@@ -64,5 +64,13 @@ namespace SharpYaml
         /// obtained first by calling the <see cref="Peek"/> method.
         /// </summary>
         void Skip(int length);
+
+        /// <summary>
+        /// Reads characters until at least <paramref name="length"/> characters are in the buffer.
+        /// </summary>
+        /// <param name="length">
+        /// Number of characters to cache.
+        /// </param>
+        void Cache(int length);
     }
 }

--- a/src/SharpYaml/Mark.cs
+++ b/src/SharpYaml/Mark.cs
@@ -56,20 +56,18 @@ namespace SharpYaml
         private int line;
         private int column;
 
+        public Mark(int index, int line, int column) {
+            this.index = index;
+            this.line = line;
+            this.column = column;
+        }
+
         /// <summary>
         /// Gets / sets the absolute offset in the file
         /// </summary>
         public int Index
         {
             get { return index; }
-            set
-            {
-                if (value < 0)
-                {
-                    throw new ArgumentOutOfRangeException("value", "Index must be greater than or equal to zero.");
-                }
-                index = value;
-            }
         }
 
         /// <summary>
@@ -78,14 +76,6 @@ namespace SharpYaml
         public int Line
         {
             get { return line; }
-            set
-            {
-                if (value < 0)
-                {
-                    throw new ArgumentOutOfRangeException("value", "Line must be greater than or equal to zero.");
-                }
-                line = value;
-            }
         }
 
         /// <summary>
@@ -94,14 +84,6 @@ namespace SharpYaml
         public int Column
         {
             get { return column; }
-            set
-            {
-                if (value < 0)
-                {
-                    throw new ArgumentOutOfRangeException("value", "Column must be greater than or equal to zero.");
-                }
-                column = value;
-            }
         }
 
         /// <summary>

--- a/src/SharpYaml/Model/YamlDocument.cs
+++ b/src/SharpYaml/Model/YamlDocument.cs
@@ -53,16 +53,6 @@ namespace SharpYaml.Model
             return new YamlDocument(documentStart, documentEnd, contents, tracker);
         }
 
-        public override IEnumerable<ParsingEvent> EnumerateEvents() {
-            yield return _documentStart;
-
-            foreach (var evnt in _contents.EnumerateEvents()) {
-                yield return evnt;
-            }
-
-            yield return _documentEnd;
-        }
-
         public DocumentStart DocumentStart {
             get => _documentStart;
             set {

--- a/src/SharpYaml/Model/YamlDocument.cs
+++ b/src/SharpYaml/Model/YamlDocument.cs
@@ -106,7 +106,7 @@ namespace SharpYaml.Model
             }
         }
 
-        public override YamlNode DeepClone() {
+        public override YamlNode DeepClone(YamlNodeTracker tracker = null) {
             var documentVersionCopy = _documentStart.Version == null
                 ? null
                 : new VersionDirective(_documentStart.Version.Version, _documentStart.Version.Start, _documentStart.Version.End);
@@ -118,7 +118,7 @@ namespace SharpYaml.Model
 
             var documentEndCopy = new DocumentEnd(_documentEnd.IsImplicit, _documentEnd.Start, _documentEnd.End);
 
-            return new YamlDocument(documentStartCopy, documentEndCopy, (YamlElement) Contents?.DeepClone(), Tracker);
+            return new YamlDocument(documentStartCopy, documentEndCopy, (YamlElement) Contents?.DeepClone(), tracker);
         }
     }
 }

--- a/src/SharpYaml/Model/YamlDocument.cs
+++ b/src/SharpYaml/Model/YamlDocument.cs
@@ -107,18 +107,7 @@ namespace SharpYaml.Model
         }
 
         public override YamlNode DeepClone(YamlNodeTracker tracker = null) {
-            var documentVersionCopy = _documentStart.Version == null
-                ? null
-                : new VersionDirective(_documentStart.Version.Version, _documentStart.Version.Start, _documentStart.Version.End);
-
-            var documentTagsCopy = _documentStart.Tags == null ? null : new TagDirectiveCollection(_documentStart.Tags);
-
-            var documentStartCopy = new DocumentStart(documentVersionCopy, documentTagsCopy, _documentStart.IsImplicit,
-                _documentStart.Start, _documentStart.End);
-
-            var documentEndCopy = new DocumentEnd(_documentEnd.IsImplicit, _documentEnd.Start, _documentEnd.End);
-
-            return new YamlDocument(documentStartCopy, documentEndCopy, (YamlElement) Contents?.DeepClone(), tracker);
+            return new YamlDocument(_documentStart, _documentEnd, (YamlElement) Contents?.DeepClone(), tracker);
         }
     }
 }

--- a/src/SharpYaml/Model/YamlMapping.cs
+++ b/src/SharpYaml/Model/YamlMapping.cs
@@ -69,6 +69,8 @@ namespace SharpYaml.Model {
                     Tracker.OnMappingStartChanged(this, oldValue, value);
             }
         }
+        
+        internal MappingEnd MappingEnd { get { return _mappingEnd;  } }
 
         public override string Anchor {
             get { return _mappingStart.Anchor; }
@@ -140,21 +142,7 @@ namespace SharpYaml.Model {
 
             return new YamlMapping(mappingStart, mappingEnd, keys, contents, tracker);
         }
-
-        public override IEnumerable<ParsingEvent> EnumerateEvents() {
-            yield return _mappingStart;
-
-            foreach (var key in _keys) {
-                foreach (var evnt in key.EnumerateEvents())
-                    yield return evnt;
-
-                foreach (var evnt in _contents[key].EnumerateEvents())
-                    yield return evnt;
-            }
-
-            yield return _mappingEnd;
-        }
-
+        
         IEnumerator IEnumerable.GetEnumerator() {
             return GetEnumerator();
         }

--- a/src/SharpYaml/Model/YamlMapping.cs
+++ b/src/SharpYaml/Model/YamlMapping.cs
@@ -416,25 +416,18 @@ namespace SharpYaml.Model {
         }
 
         public override YamlNode DeepClone(YamlNodeTracker tracker = null) {
-            var mappingStartCopy = new MappingStart(_mappingStart.Anchor,
-                _mappingStart.Tag,
-                _mappingStart.IsImplicit,
-                _mappingStart.Style,
-                _mappingStart.Start,
-                _mappingStart.End);
-
-            var mappingEndCopy = new MappingEnd(_mappingEnd.Start, _mappingEnd.End);
-
-            var cloneKeys = _keys.Select(k => (YamlElement) k.DeepClone()).ToList();
+            var keysClone = new List<YamlElement>(_keys.Count);
+            for (var i = 0; i < _keys.Count; i++)
+                keysClone.Add((YamlElement)_keys[i].DeepClone());
 
             var cloneContents = new Dictionary<YamlElement, YamlElement>();
 
             for (var i = 0; i < _keys.Count; i++)
-                cloneContents[cloneKeys[i]] = (YamlElement) _contents[_keys[i]].DeepClone();
+                cloneContents[keysClone[i]] = (YamlElement) _contents[_keys[i]].DeepClone();
 
-            return new YamlMapping(mappingStartCopy,
-                mappingEndCopy,
-                cloneKeys,
+            return new YamlMapping(_mappingStart,
+                _mappingEnd,
+                keysClone,
                 cloneContents,
                 tracker);
         }

--- a/src/SharpYaml/Model/YamlMapping.cs
+++ b/src/SharpYaml/Model/YamlMapping.cs
@@ -415,7 +415,7 @@ namespace SharpYaml.Model {
             }
         }
 
-        public override YamlNode DeepClone() {
+        public override YamlNode DeepClone(YamlNodeTracker tracker = null) {
             var mappingStartCopy = new MappingStart(_mappingStart.Anchor,
                 _mappingStart.Tag,
                 _mappingStart.IsImplicit,
@@ -436,7 +436,7 @@ namespace SharpYaml.Model {
                 mappingEndCopy,
                 cloneKeys,
                 cloneContents,
-                Tracker);
+                tracker);
         }
     }
 }

--- a/src/SharpYaml/Model/YamlNode.cs
+++ b/src/SharpYaml/Model/YamlNode.cs
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -29,7 +30,7 @@ using Scalar = SharpYaml.Events.Scalar;
 using StreamStart = SharpYaml.Events.StreamStart;
 
 namespace SharpYaml.Model {
-    public abstract class YamlNode {
+     public abstract class YamlNode {
         public virtual YamlNodeTracker Tracker { get; internal set; }
 
         protected static YamlElement ReadElement(EventReader eventReader, YamlNodeTracker tracker = null) {
@@ -45,7 +46,9 @@ namespace SharpYaml.Model {
             return null;
         }
 
-        public abstract IEnumerable<ParsingEvent> EnumerateEvents();
+        public IEnumerable<ParsingEvent> EnumerateEvents() {
+            return new YamlNodeEventEnumerator(this);
+        }
 
         public void WriteTo(TextWriter writer, bool suppressDocumentTags = false) {
             WriteTo(new Emitter(writer), suppressDocumentTags);

--- a/src/SharpYaml/Model/YamlNode.cs
+++ b/src/SharpYaml/Model/YamlNode.cs
@@ -114,6 +114,6 @@ namespace SharpYaml.Model {
             return ReadElement(new EventReader(new MemoryParser(emitter.Events)));
         }
 
-        public abstract YamlNode DeepClone();
+        public abstract YamlNode DeepClone(YamlNodeTracker tracker = null);
     }
 }

--- a/src/SharpYaml/Model/YamlNodeEventEnumerator.cs
+++ b/src/SharpYaml/Model/YamlNodeEventEnumerator.cs
@@ -22,14 +22,14 @@ using System.Collections.Generic;
 using SharpYaml.Events;
 
 namespace SharpYaml.Model {
-    public struct YamlNodeEventEnumerator : IEnumerable<ParsingEvent>, IEnumerator<ParsingEvent> {
-        private YamlNode root;
+    public sealed class YamlNodeEventEnumerator : IEnumerable<ParsingEvent>, IEnumerator<ParsingEvent> {
+        private readonly YamlNode root;
         private YamlNode currentNode;
         private int currentIndex;
         private Stack<YamlNode> nodePath;
         private Stack<int> indexPath;
 
-        public YamlNodeEventEnumerator(YamlNode root) : this() {
+        public YamlNodeEventEnumerator(YamlNode root) {
             this.root = root;
             currentNode = root;
             currentIndex = -1;

--- a/src/SharpYaml/Model/YamlNodeEventEnumerator.cs
+++ b/src/SharpYaml/Model/YamlNodeEventEnumerator.cs
@@ -1,0 +1,185 @@
+// Copyright (c) SharpYaml - Alexandre Mutel
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using SharpYaml.Events;
+using SharpYaml.Serialization;
+using DocumentStart = SharpYaml.Events.DocumentStart;
+using Scalar = SharpYaml.Events.Scalar;
+using StreamStart = SharpYaml.Events.StreamStart;
+
+namespace SharpYaml.Model {
+    public struct YamlNodeEventEnumerator : IEnumerable<ParsingEvent>, IEnumerator<ParsingEvent> {
+        private YamlNode root;
+        private YamlNode currentNode;
+        private int currentIndex;
+        private Stack<YamlNode> nodePath;
+        private Stack<int> indexPath;
+
+        public YamlNodeEventEnumerator(YamlNode root) : this() {
+            this.root = root;
+            currentNode = root;
+            currentIndex = -1;
+        }
+
+        public IEnumerator<ParsingEvent> GetEnumerator() {
+            return this;
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() {
+            return GetEnumerator();
+        }
+
+        public void Dispose() { }
+
+        public bool MoveNext() {
+            if (currentNode == null)
+                return false;
+            
+            if (nodePath == null) {
+                nodePath = new Stack<YamlNode>();
+                indexPath = new Stack<int>();
+            }
+            
+            if (currentNode is YamlStream stream) {
+                if (currentIndex == -1) {
+                    Current = stream.StreamStart;
+                    currentIndex++;
+                    return true;
+                } 
+                
+                if (currentIndex < stream.Count) {
+                    nodePath.Push(currentNode);
+                    indexPath.Push(currentIndex);
+                    currentNode = stream[currentIndex];
+                    currentIndex = -1;
+                    MoveNext();
+                    return true;
+                } 
+                  
+                Current = stream.StreamEnd;
+                Pop();
+                return true;
+            }
+
+            if (currentNode is YamlDocument document) {
+                if (currentIndex == -1) {
+                    Current = document.DocumentStart;
+                    currentIndex++;
+                    return true;
+                }
+
+                if (currentIndex < 1) {
+                    nodePath.Push(currentNode);
+                    indexPath.Push(currentIndex);
+                    currentNode = document.Contents;
+                    currentIndex = -1;
+                    MoveNext();
+                    return true;
+                }
+
+                Current = document.DocumentEnd;
+                Pop();
+                return true;
+            }
+
+            if (currentNode is YamlMapping mapping) {
+                if (currentIndex == -1) {
+                    Current = mapping.MappingStart;
+                    currentIndex++;
+                    return true;
+                }
+
+                if (currentIndex < mapping.Count * 2) {
+                    nodePath.Push(currentNode);
+                    indexPath.Push(currentIndex);
+                    if (currentIndex % 2 == 0) {
+                        currentNode = ((List<YamlElement>) mapping.Keys)[currentIndex / 2];
+                        currentIndex = -1;
+                    } else {
+                        currentNode = mapping[(currentIndex - 1) / 2].Value;
+                        currentIndex = -1;
+                    }
+                    MoveNext();
+                    return true;
+                }
+
+                Current = mapping.MappingEnd;
+                Pop();
+                return true;
+            }
+
+            if (currentNode is YamlSequence sequence) {
+                if (currentIndex == -1) {
+                    Current = sequence.SequenceStart;
+                    currentIndex++;
+                    return true;
+                }
+
+                if (currentIndex < sequence.Count) {
+                    nodePath.Push(currentNode);
+                    indexPath.Push(currentIndex);
+                    currentNode = sequence[currentIndex];
+                    currentIndex = -1;
+                    MoveNext();
+                    return true;
+                }
+
+                Current = sequence.SequenceEnd;
+                Pop();
+                return true;
+            }
+
+            if (currentNode is YamlValue value) {
+                Current = value.Scalar;
+                Pop();
+                return true;
+            }
+
+            return false;
+        }
+
+        void Pop() {
+            if (currentNode == root) {
+                currentNode = null;
+                return;
+            }
+            
+            currentNode = nodePath.Pop();
+            currentIndex = indexPath.Pop() + 1;
+        }
+        
+        public void Reset() {
+            Current = null;
+            nodePath.Clear();
+            indexPath.Clear();
+            currentNode = root;
+            currentIndex = -1;
+        }
+
+        public ParsingEvent Current { get; private set; }
+
+        object IEnumerator.Current => Current;
+    }
+}

--- a/src/SharpYaml/Model/YamlNodeTracker.cs
+++ b/src/SharpYaml/Model/YamlNodeTracker.cs
@@ -359,9 +359,13 @@ namespace SharpYaml.Model {
                 return;
             }
 
-            if (set is ParentAndIndex[]) {
+            var array = set as ParentAndIndex[];
+            if (array != null) {
+                if (array[0].Equals(pi))
+                    return;
+                
                 var newSet = new HashSet<ParentAndIndex>();
-                newSet.Add(set.First());
+                newSet.Add(array[0]);
                 parents.Remove(child);
                 set = newSet;
                 parents.Add(child, set);

--- a/src/SharpYaml/Model/YamlNodeTracker.cs
+++ b/src/SharpYaml/Model/YamlNodeTracker.cs
@@ -344,34 +344,48 @@ namespace SharpYaml.Model {
         }
 
 #if NET35
-        Dictionary<YamlNode, HashSet<ParentAndIndex>> parents = new Dictionary<YamlNode, HashSet<ParentAndIndex>>();
+        Dictionary<YamlNode, ICollection<ParentAndIndex>> parents = new Dictionary<YamlNode, ICollection<ParentAndIndex>>();
 #else
-        private ConditionalWeakTable<YamlNode, HashSet<ParentAndIndex>> parents = new ConditionalWeakTable<YamlNode, HashSet<ParentAndIndex>>();
+        private ConditionalWeakTable<YamlNode, ICollection<ParentAndIndex>> parents = new ConditionalWeakTable<YamlNode, ICollection<ParentAndIndex>>();
 #endif
         
         void AddChild(YamlNode child, YamlNode parent, ChildIndex relationship) {
-            HashSet<ParentAndIndex> set;
+            var pi = new ParentAndIndex(parent, relationship);
+
+            ICollection<ParentAndIndex> set;
             if (!parents.TryGetValue(child, out set)) {
-                set = new HashSet<ParentAndIndex>();
+                set = new[] { pi };
+                parents.Add(child, set);
+                return;
+            }
+
+            if (set is ParentAndIndex[]) {
+                var newSet = new HashSet<ParentAndIndex>();
+                newSet.Add(set.First());
+                parents.Remove(child);
+                set = newSet;
                 parents.Add(child, set);
             }
 
-            set.Add(new ParentAndIndex(parent, relationship));
+            set.Add(pi);
         }
 
         void RemoveChild(YamlNode child, YamlNode parent, ChildIndex relationship) {
-            HashSet<ParentAndIndex> set;
+            ICollection<ParentAndIndex> set;
             if (!parents.TryGetValue(child, out set))
                 return;
 
-            set.Remove(new ParentAndIndex(parent, relationship));
+            if (set is ParentAndIndex[])
+                parents.Remove(child);
+            else
+                set.Remove(new ParentAndIndex(parent, relationship));
         }
 
         public IList<Path> GetPaths(YamlNode child) {
             if (child is YamlStream)
                 return new Path[0];
 
-            HashSet<ParentAndIndex> relationships;
+            ICollection<ParentAndIndex> relationships;
             if (!parents.TryGetValue(child, out relationships))
                 return new Path[0];
 

--- a/src/SharpYaml/Model/YamlSequence.cs
+++ b/src/SharpYaml/Model/YamlSequence.cs
@@ -62,6 +62,8 @@ namespace SharpYaml.Model
                     Tracker.OnSequenceStartChanged(this, _sequenceStart, value);
             }
         }
+        
+        internal SequenceEnd SequenceEnd { get { return _sequenceEnd; } }
 
         public override string Anchor {
             get { return _sequenceStart.Anchor; }
@@ -126,18 +128,6 @@ namespace SharpYaml.Model
             var sequenceEnd = eventReader.Allow<SequenceEnd>();
 
             return new YamlSequence(sequenceStart, sequenceEnd, contents, tracker);
-        }
-
-        public override IEnumerable<ParsingEvent> EnumerateEvents() {
-            yield return _sequenceStart;
-
-            foreach (var item in _contents) {
-                foreach (var evnt in item.EnumerateEvents()) {
-                    yield return evnt;
-                }
-            }
-
-            yield return _sequenceEnd;
         }
 
         IEnumerator IEnumerable.GetEnumerator() {

--- a/src/SharpYaml/Model/YamlSequence.cs
+++ b/src/SharpYaml/Model/YamlSequence.cs
@@ -233,16 +233,11 @@ namespace SharpYaml.Model
         }
 
         public override YamlNode DeepClone(YamlNodeTracker tracker = null) {
-            var sequenceStartCopy = new SequenceStart(_sequenceStart.Anchor, 
-                _sequenceStart.Tag, 
-                _sequenceStart.IsImplicit, 
-                _sequenceStart.Style, 
-                _sequenceStart.Start, 
-                _sequenceStart.End);
+            var contentsClone = new List<YamlElement>(_contents.Count);
+            for (var i = 0; i < _contents.Count; i++)
+                contentsClone.Add((YamlElement) _contents[i].DeepClone());
 
-            var sequenceEndCopy = new SequenceEnd(_sequenceEnd.Start, _sequenceEnd.End);
-
-            return new YamlSequence(sequenceStartCopy, sequenceEndCopy, _contents.Select(c => (YamlElement) c.DeepClone()).ToList(), tracker);
+            return new YamlSequence(_sequenceStart, _sequenceEnd, contentsClone, tracker);
         }
     }
 }

--- a/src/SharpYaml/Model/YamlSequence.cs
+++ b/src/SharpYaml/Model/YamlSequence.cs
@@ -232,7 +232,7 @@ namespace SharpYaml.Model
             }
         }
 
-        public override YamlNode DeepClone() {
+        public override YamlNode DeepClone(YamlNodeTracker tracker = null) {
             var sequenceStartCopy = new SequenceStart(_sequenceStart.Anchor, 
                 _sequenceStart.Tag, 
                 _sequenceStart.IsImplicit, 
@@ -242,7 +242,7 @@ namespace SharpYaml.Model
 
             var sequenceEndCopy = new SequenceEnd(_sequenceEnd.Start, _sequenceEnd.End);
 
-            return new YamlSequence(sequenceStartCopy, sequenceEndCopy, _contents.Select(c => (YamlElement) c.DeepClone()).ToList(), Tracker);
+            return new YamlSequence(sequenceStartCopy, sequenceEndCopy, _contents.Select(c => (YamlElement) c.DeepClone()).ToList(), tracker);
         }
     }
 }

--- a/src/SharpYaml/Model/YamlStream.cs
+++ b/src/SharpYaml/Model/YamlStream.cs
@@ -55,7 +55,7 @@ namespace SharpYaml.Model
         }
 
         public static YamlStream Load(TextReader stream, YamlNodeTracker tracker = null) {
-            return Load(new EventReader(new Parser(stream)), tracker);
+            return Load(new EventReader(Parser.CreateParser(stream)), tracker);
         }
 
         public static YamlStream Load(EventReader eventReader, YamlNodeTracker tracker = null) {

--- a/src/SharpYaml/Model/YamlStream.cs
+++ b/src/SharpYaml/Model/YamlStream.cs
@@ -175,10 +175,11 @@ namespace SharpYaml.Model
             }
         }
 
-        public override YamlNode DeepClone() {
+        public override YamlNode DeepClone(YamlNodeTracker tracker = null) {
             return new YamlStream(new StreamStart(_streamStart.Start, _streamStart.End),
                 new StreamEnd(_streamEnd.Start, _streamEnd.End),
-                _documents.Select(d => (YamlDocument)d.DeepClone()).ToList());
+                _documents.Select(d => (YamlDocument)d.DeepClone(tracker)).ToList(), 
+                tracker);
         }
     }
 }

--- a/src/SharpYaml/Model/YamlStream.cs
+++ b/src/SharpYaml/Model/YamlStream.cs
@@ -23,8 +23,7 @@ using System.IO;
 using System.Linq;
 using SharpYaml.Events;
 
-namespace SharpYaml.Model
-{
+namespace SharpYaml.Model {
     public class YamlStream : YamlNode, IList<YamlDocument> {
         private readonly StreamStart _streamStart;
         private readonly StreamEnd _streamEnd;
@@ -89,7 +88,7 @@ namespace SharpYaml.Model
                 Tracker.OnStreamAddDocument(this, item, _documents.Count - 1);
             }
         }
-        
+
         public override YamlNodeTracker Tracker {
             get { return base.Tracker; }
             internal set {
@@ -176,10 +175,11 @@ namespace SharpYaml.Model
         }
 
         public override YamlNode DeepClone(YamlNodeTracker tracker = null) {
-            return new YamlStream(new StreamStart(_streamStart.Start, _streamStart.End),
-                new StreamEnd(_streamEnd.Start, _streamEnd.End),
-                _documents.Select(d => (YamlDocument)d.DeepClone(tracker)).ToList(), 
-                tracker);
+            var documentsClone = new List<YamlDocument>(_documents.Count);
+            for (var i = 0; i < _documents.Count; i++)
+                documentsClone.Add((YamlDocument)_documents[i].DeepClone());
+
+            return new YamlStream(_streamStart, _streamEnd, documentsClone, tracker);
         }
     }
 }

--- a/src/SharpYaml/Model/YamlStream.cs
+++ b/src/SharpYaml/Model/YamlStream.cs
@@ -54,6 +54,9 @@ namespace SharpYaml.Model
             }
         }
 
+        internal StreamStart StreamStart { get { return _streamStart; } }
+        internal StreamEnd StreamEnd { get { return _streamEnd; } }
+
         public static YamlStream Load(TextReader stream, YamlNodeTracker tracker = null) {
             return Load(new EventReader(Parser.CreateParser(stream)), tracker);
         }
@@ -68,19 +71,6 @@ namespace SharpYaml.Model
             var streamEnd = eventReader.Allow<StreamEnd>();
 
             return new YamlStream(streamStart, streamEnd, documents, tracker);
-        }
-
-        public override IEnumerable<ParsingEvent> EnumerateEvents() {
-            yield return _streamStart;
-
-            foreach (var document in _documents) {
-                foreach (var evnt in document.EnumerateEvents()) {
-                    yield return evnt;
-                }
-            }
-
-
-            yield return _streamEnd;
         }
 
         IEnumerator IEnumerable.GetEnumerator() {

--- a/src/SharpYaml/Model/YamlValue.cs
+++ b/src/SharpYaml/Model/YamlValue.cs
@@ -62,15 +62,7 @@ namespace SharpYaml.Model
         }
 
         public override YamlNode DeepClone(YamlNodeTracker tracker = null) {
-            return new YamlValue(new Scalar(_scalar.Anchor,
-                _scalar.Tag,
-                _scalar.Value,
-                _scalar.Style,
-                _scalar.IsPlainImplicit,
-                _scalar.IsQuotedImplicit,
-                _scalar.Start,
-                _scalar.End),
-                tracker);
+            return new YamlValue(_scalar, tracker);
         }
 
         public override string Anchor {

--- a/src/SharpYaml/Model/YamlValue.cs
+++ b/src/SharpYaml/Model/YamlValue.cs
@@ -61,7 +61,7 @@ namespace SharpYaml.Model
             return new YamlValue(scalar, tracker);
         }
 
-        public override YamlNode DeepClone() {
+        public override YamlNode DeepClone(YamlNodeTracker tracker = null) {
             return new YamlValue(new Scalar(_scalar.Anchor,
                 _scalar.Tag,
                 _scalar.Value,
@@ -70,7 +70,7 @@ namespace SharpYaml.Model
                 _scalar.IsQuotedImplicit,
                 _scalar.Start,
                 _scalar.End),
-                Tracker);
+                tracker);
         }
 
         public override string Anchor {

--- a/src/SharpYaml/Model/YamlValue.cs
+++ b/src/SharpYaml/Model/YamlValue.cs
@@ -43,7 +43,7 @@ namespace SharpYaml.Model
             Scalar = new Scalar(schema.GetDefaultTag(value.GetType()), valueString);
         }
 
-        private Scalar Scalar {
+        internal Scalar Scalar {
             get { return _scalar; }
             set {
                 var oldScalar = _scalar;
@@ -59,10 +59,6 @@ namespace SharpYaml.Model
             var scalar = eventReader.Allow<Scalar>();
 
             return new YamlValue(scalar, tracker);
-        }
-
-        public override IEnumerable<ParsingEvent> EnumerateEvents() {
-            yield return _scalar;
         }
 
         public override YamlNode DeepClone() {

--- a/src/SharpYaml/Scanner.cs
+++ b/src/SharpYaml/Scanner.cs
@@ -89,7 +89,7 @@ namespace SharpYaml
         private int tokensParsed;
 
         public const int MaxBufferLength = 12; // Number of characters in two 8 bit unicode codepoints.
-        private readonly CharacterAnalyzer<TBuffer> analyzer;
+        private readonly TBuffer analyzer;
         private bool tokenAvailable;
 
         private static readonly IDictionary<char, char> simpleEscapeCodes = InitializeSimpleEscapeCodes();
@@ -145,7 +145,7 @@ namespace SharpYaml
         /// <param name="buffer">The buffer.</param>
         public Scanner(TBuffer buffer)
         {
-            analyzer = new CharacterAnalyzer<TBuffer>(buffer);
+            analyzer = buffer;
         }
 
         private Token current;
@@ -305,11 +305,11 @@ namespace SharpYaml
             // of the longest indicators ('--- ' and '... ').
 
 
-            analyzer.Buffer.Cache(4);
+            analyzer.Cache(4);
 
             // Is it the end of the stream?
 
-            if (analyzer.Buffer.EndOfInput)
+            if (analyzer.EndOfInput)
             {
                 FetchStreamEnd();
                 return;
@@ -533,7 +533,7 @@ namespace SharpYaml
         {
             ++index;
             ++column;
-            analyzer.Buffer.Skip(1);
+            analyzer.Skip(1);
         }
 
         private void SkipLine()
@@ -543,14 +543,14 @@ namespace SharpYaml
                 index += 2;
                 column = 0;
                 ++line;
-                analyzer.Buffer.Skip(2);
+                analyzer.Skip(2);
             }
             else if (analyzer.IsBreak())
             {
                 ++index;
                 column = 0;
                 ++line;
-                analyzer.Buffer.Skip(1);
+                analyzer.Skip(1);
             }
             else if (!analyzer.IsZero())
             {

--- a/src/SharpYaml/Scanner.cs
+++ b/src/SharpYaml/Scanner.cs
@@ -1829,10 +1829,10 @@ namespace SharpYaml
         /// </summary>
         private Token ScanPlainScalar()
         {
-            StringBuilder value = new StringBuilder();
-            StringBuilder whitespaces = null;
-            StringBuilder leadingBreak = null;
-            StringBuilder trailingBreaks = null;
+            scanScalarValue.Length = 0;
+            scanScalarWhitespaces.Length = 0;
+            scanScalarLeadingBreak.Length = 0;
+            scanScalarTrailingBreaks.Length = 0;
 
             bool hasLeadingBlanks = false;
             int currentIndent = indent + 1;
@@ -1877,45 +1877,44 @@ namespace SharpYaml
 
                     // Check if we need to join whitespaces and breaks.
 
-                    if (hasLeadingBlanks || whitespaces?.Length > 0)
+                    if (hasLeadingBlanks || scanScalarWhitespaces.Length > 0)
                     {
                         if (hasLeadingBlanks)
                         {
                             // Do we need to fold line breaks?
 
-                            if (StartsWith(leadingBreak, '\n'))
+                            if (StartsWith(scanScalarLeadingBreak, '\n'))
                             {
-                                if (trailingBreaks?.Length == 0)
+                                if (scanScalarTrailingBreaks.Length == 0)
                                 {
-                                    value.Append(' ');
+                                    scanScalarValue.Append(' ');
                                 }
                                 else
                                 {
-                                    value.Append(trailingBreaks);
+                                    scanScalarValue.Append(scanScalarTrailingBreaks);
                                 }
                             }
                             else
                             {
-                                value.Append(leadingBreak);
-                                value.Append(trailingBreaks);
+                                scanScalarValue.Append(scanScalarLeadingBreak);
+                                scanScalarValue.Append(scanScalarTrailingBreaks);
                             }
 
-                            leadingBreak.Length = 0;
-                            if (trailingBreaks != null)
-                                trailingBreaks.Length = 0;
+                            scanScalarLeadingBreak.Length = 0;
+                            scanScalarTrailingBreaks.Length = 0;
 
                             hasLeadingBlanks = false;
                         }
                         else
                         {
-                            value.Append(whitespaces);
-                            whitespaces.Length = 0;
+                            scanScalarValue.Append(scanScalarWhitespaces);
+                            scanScalarWhitespaces.Length = 0;
                         }
                     }
 
                     // Copy the character.
 
-                    value.Append(ReadCurrentCharacter());
+                    scanScalarValue.Append(ReadCurrentCharacter());
 
                     end = CurrentPosition;
                 }
@@ -1943,9 +1942,7 @@ namespace SharpYaml
                         // Consume a space or a tab character.
 
                         if (!hasLeadingBlanks) {
-                            if (whitespaces == null)
-                                whitespaces = new StringBuilder();
-                            whitespaces.Append(ReadCurrentCharacter());
+                            scanScalarWhitespaces.Append(ReadCurrentCharacter());
                         }
                         else
                         {
@@ -1958,17 +1955,12 @@ namespace SharpYaml
 
                         if (!hasLeadingBlanks)
                         {
-                            if (whitespaces != null)
-                                whitespaces.Length = 0;
-                            if (leadingBreak == null)
-                                leadingBreak = new StringBuilder();
-                            leadingBreak.Append(ReadLine());
+                            scanScalarWhitespaces.Length = 0;
+                            scanScalarLeadingBreak.Append(ReadLine());
                             hasLeadingBlanks = true;
                         }
                         else {
-                            if (trailingBreaks == null)
-                                trailingBreaks = new StringBuilder();
-                            trailingBreaks.Append(ReadLine());
+                            scanScalarTrailingBreaks.Append(ReadLine());
                         }
                     }
                 }
@@ -1990,7 +1982,7 @@ namespace SharpYaml
 
             // Create a token.
 
-            return new Scalar(value.ToString(), ScalarStyle.Plain, start, end);
+            return new Scalar(scanScalarValue.ToString(), ScalarStyle.Plain, start, end);
         }
 
 

--- a/src/SharpYaml/Scanner.cs
+++ b/src/SharpYaml/Scanner.cs
@@ -1829,9 +1829,9 @@ namespace SharpYaml
         private Token ScanPlainScalar()
         {
             StringBuilder value = new StringBuilder();
-            StringBuilder whitespaces = new StringBuilder();
-            StringBuilder leadingBreak = new StringBuilder();
-            StringBuilder trailingBreaks = new StringBuilder();
+            StringBuilder whitespaces = null;
+            StringBuilder leadingBreak = null;
+            StringBuilder trailingBreaks = null;
 
             bool hasLeadingBlanks = false;
             int currentIndent = indent + 1;
@@ -1876,7 +1876,7 @@ namespace SharpYaml
 
                     // Check if we need to join whitespaces and breaks.
 
-                    if (hasLeadingBlanks || whitespaces.Length > 0)
+                    if (hasLeadingBlanks || whitespaces?.Length > 0)
                     {
                         if (hasLeadingBlanks)
                         {
@@ -1884,7 +1884,7 @@ namespace SharpYaml
 
                             if (StartsWith(leadingBreak, '\n'))
                             {
-                                if (trailingBreaks.Length == 0)
+                                if (trailingBreaks?.Length == 0)
                                 {
                                     value.Append(' ');
                                 }
@@ -1900,7 +1900,8 @@ namespace SharpYaml
                             }
 
                             leadingBreak.Length = 0;
-                            trailingBreaks.Length = 0;
+                            if (trailingBreaks != null)
+                                trailingBreaks.Length = 0;
 
                             hasLeadingBlanks = false;
                         }
@@ -1940,8 +1941,9 @@ namespace SharpYaml
 
                         // Consume a space or a tab character.
 
-                        if (!hasLeadingBlanks)
-                        {
+                        if (!hasLeadingBlanks) {
+                            if (whitespaces == null)
+                                whitespaces = new StringBuilder();
                             whitespaces.Append(ReadCurrentCharacter());
                         }
                         else
@@ -1955,12 +1957,16 @@ namespace SharpYaml
 
                         if (!hasLeadingBlanks)
                         {
-                            whitespaces.Length = 0;
+                            if (whitespaces != null)
+                                whitespaces.Length = 0;
+                            if (leadingBreak == null)
+                                leadingBreak = new StringBuilder();
                             leadingBreak.Append(ReadLine());
                             hasLeadingBlanks = true;
                         }
-                        else
-                        {
+                        else {
+                            if (trailingBreaks == null)
+                                trailingBreaks = new StringBuilder();
                             trailingBreaks.Append(ReadLine());
                         }
                     }

--- a/src/SharpYaml/Scanner.cs
+++ b/src/SharpYaml/Scanner.cs
@@ -55,7 +55,7 @@ namespace SharpYaml
     /// <summary>
     /// Converts a sequence of characters into a sequence of YAML tokens.
     /// </summary>
-    public class Scanner
+    public class Scanner<TBuffer> where TBuffer : ILookAheadBuffer
     {
         private const int MaxVersionNumberLength = 9;
 
@@ -85,8 +85,8 @@ namespace SharpYaml
         private int flowLevel;
         private int tokensParsed;
 
-        private const int MaxBufferLength = 12; // Number of characters in two 8 bit unicode codepoints.
-        private readonly CharacterAnalyzer<LookAheadBuffer> analyzer;
+        public const int MaxBufferLength = 12; // Number of characters in two 8 bit unicode codepoints.
+        private readonly CharacterAnalyzer<TBuffer> analyzer;
         private bool tokenAvailable;
 
         private static readonly IDictionary<char, char> simpleEscapeCodes = InitializeSimpleEscapeCodes();
@@ -139,10 +139,10 @@ namespace SharpYaml
         /// <summary>
         /// Initializes a new instance of the <see cref="Scanner"/> class.
         /// </summary>
-        /// <param name="input">The input.</param>
-        public Scanner(TextReader input)
+        /// <param name="buffer">The buffer.</param>
+        public Scanner(TBuffer buffer)
         {
-            analyzer = new CharacterAnalyzer<LookAheadBuffer>(new LookAheadBuffer(input, MaxBufferLength));
+            analyzer = new CharacterAnalyzer<TBuffer>(buffer);
             mark.Column = 0;
             mark.Line = 0;
         }

--- a/src/SharpYaml/Scanner.cs
+++ b/src/SharpYaml/Scanner.cs
@@ -74,13 +74,16 @@ namespace SharpYaml
         private bool streamEndProduced;
         private int indent = -1;
         private bool simpleKeyAllowed;
-        private Mark mark;
 
+        private int index = 0;
+        private int line = 0;
+        private int column = 0;
+        
         /// <summary>
         /// Gets the current position inside the input stream.
         /// </summary>
         /// <value>The current position.</value>
-        public Mark CurrentPosition { get { return mark; } }
+        public Mark CurrentPosition { get { return new Mark(index, line, column); } }
 
         private int flowLevel;
         private int tokensParsed;
@@ -143,8 +146,6 @@ namespace SharpYaml
         public Scanner(TBuffer buffer)
         {
             analyzer = new CharacterAnalyzer<TBuffer>(buffer);
-            mark.Column = 0;
-            mark.Line = 0;
         }
 
         private Token current;
@@ -263,13 +264,13 @@ namespace SharpYaml
                 //  - is shorter than 1024 characters.
 
 
-                if (key.IsPossible && (key.Mark.Line < mark.Line || key.Mark.Index + 1024 < mark.Index))
+                if (key.IsPossible && (key.Mark.Line < line || key.Mark.Index + 1024 < index))
                 {
                     // Check if the potential simple key to be removed is required.
 
                     if (key.IsRequired)
                     {
-                        throw new SyntaxErrorException(mark, mark, "While scanning a simple key, could not find expected ':'.");
+                        throw new SyntaxErrorException(CurrentPosition, CurrentPosition, "While scanning a simple key, could not find expected ':'.");
                     }
 
                     key.IsPossible = false;
@@ -297,7 +298,7 @@ namespace SharpYaml
 
             // Check the indentation level against the current column.
 
-            UnrollIndent(mark.Column);
+            UnrollIndent(column);
 
 
             // Ensure that the buffer contains at least 4 characters.  4 is the length
@@ -316,7 +317,7 @@ namespace SharpYaml
 
             // Is it a directive?
 
-            if (mark.Column == 0 && analyzer.Check('%'))
+            if (column == 0 && analyzer.Check('%'))
             {
                 FetchDirective();
                 return;
@@ -325,7 +326,7 @@ namespace SharpYaml
             // Is it the document start indicator?
 
             bool isDocumentStart =
-                mark.Column == 0 &&
+                column == 0 &&
                 analyzer.Check('-', 0) &&
                 analyzer.Check('-', 1) &&
                 analyzer.Check('-', 2) &&
@@ -340,7 +341,7 @@ namespace SharpYaml
             // Is it the document end indicator?
 
             bool isDocumentEnd =
-                mark.Column == 0 &&
+                column == 0 &&
                 analyzer.Check('.', 0) &&
                 analyzer.Check('.', 1) &&
                 analyzer.Check('.', 2) &&
@@ -505,7 +506,7 @@ namespace SharpYaml
             }
 
             // If we don't determine the token type so far, it is an error.
-            throw new SyntaxErrorException(mark, mark, "While scanning for the next token, find character that cannot start any token.");
+            throw new SyntaxErrorException(CurrentPosition, CurrentPosition, "While scanning for the next token, find character that cannot start any token.");
         }
 
         private bool CheckWhiteSpace()
@@ -515,7 +516,7 @@ namespace SharpYaml
 
         private bool IsDocumentIndicator()
         {
-            if (mark.Column == 0 && analyzer.IsBlankOrBreakOrZero(3))
+            if (column == 0 && analyzer.IsBlankOrBreakOrZero(3))
             {
                 bool isDocumentStart = analyzer.Check('-', 0) && analyzer.Check('-', 1) && analyzer.Check('-', 2);
                 bool isDocumentEnd = analyzer.Check('.', 0) && analyzer.Check('.', 1) && analyzer.Check('.', 2);
@@ -530,8 +531,8 @@ namespace SharpYaml
 
         private void Skip()
         {
-            ++mark.Index;
-            ++mark.Column;
+            ++index;
+            ++column;
             analyzer.Buffer.Skip(1);
         }
 
@@ -539,16 +540,16 @@ namespace SharpYaml
         {
             if (analyzer.IsCrLf())
             {
-                mark.Index += 2;
-                mark.Column = 0;
-                ++mark.Line;
+                index += 2;
+                column = 0;
+                ++line;
                 analyzer.Buffer.Skip(2);
             }
             else if (analyzer.IsBreak())
             {
-                ++mark.Index;
-                mark.Column = 0;
-                ++mark.Line;
+                ++index;
+                column = 0;
+                ++line;
                 analyzer.Buffer.Skip(1);
             }
             else if (!analyzer.IsZero())
@@ -625,7 +626,7 @@ namespace SharpYaml
 
             // Create the STREAM-START token and append it to the queue.
 
-            tokens.Enqueue(new StreamStart(mark, mark));
+            tokens.Enqueue(new StreamStart(CurrentPosition, CurrentPosition));
         }
 
         /// <summary>
@@ -648,7 +649,7 @@ namespace SharpYaml
             {
                 // Create a token and append it to the queue.
 
-                tokens.Enqueue(new BlockEnd(mark, mark));
+                tokens.Enqueue(new BlockEnd(CurrentPosition, CurrentPosition));
 
                 // Pop the indentation level.
 
@@ -663,10 +664,10 @@ namespace SharpYaml
         {
             // Force new line.
 
-            if (mark.Column != 0)
+            if (column != 0)
             {
-                mark.Column = 0;
-                ++mark.Line;
+                column = 0;
+                ++line;
             }
 
             // Reset the indentation level.
@@ -682,7 +683,7 @@ namespace SharpYaml
             // Create the STREAM-END token and append it to the queue.
 
             streamEndProduced = true;
-            tokens.Enqueue(new StreamEnd(mark, mark));
+            tokens.Enqueue(new StreamEnd(CurrentPosition, CurrentPosition));
         }
 
         private void FetchDirective()
@@ -719,7 +720,7 @@ namespace SharpYaml
         {
             // Eat '%'.
 
-            Mark start = mark;
+            Mark start = CurrentPosition;
 
             Skip();
 
@@ -741,7 +742,7 @@ namespace SharpYaml
                     break;
 
                 default:
-                    throw new SyntaxErrorException(start, mark, "While scanning a directive, find uknown directive name.");
+                    throw new SyntaxErrorException(start, CurrentPosition, "While scanning a directive, find uknown directive name.");
             }
 
             // Eat the rest of the line including any comments.
@@ -763,7 +764,7 @@ namespace SharpYaml
 
             if (!analyzer.IsBreakOrZero())
             {
-                throw new SyntaxErrorException(start, mark, "While scanning a directive, did not find expected comment or line break.");
+                throw new SyntaxErrorException(start, CurrentPosition, "While scanning a directive, did not find expected comment or line break.");
             }
 
             // Eat a line break.
@@ -793,13 +794,13 @@ namespace SharpYaml
 
             // Consume the token.
 
-            Mark start = mark;
+            Mark start = CurrentPosition;
 
             Skip();
             Skip();
             Skip();
 
-            Token token = isStartToken ? (Token) new DocumentStart(start, mark) : new DocumentEnd(start, start);
+            Token token = isStartToken ? (Token) new DocumentStart(start, CurrentPosition) : new DocumentEnd(start, start);
             tokens.Enqueue(token);
         }
 
@@ -822,7 +823,7 @@ namespace SharpYaml
 
             // Consume the token.
 
-            Mark start = mark;
+            Mark start = CurrentPosition;
             Skip();
 
             // Create the FLOW-SEQUENCE-START of FLOW-MAPPING-START token.
@@ -873,7 +874,7 @@ namespace SharpYaml
 
             // Consume the token.
 
-            Mark start = mark;
+            Mark start = CurrentPosition;
             Skip();
 
             Token token;
@@ -917,12 +918,12 @@ namespace SharpYaml
 
             // Consume the token.
 
-            Mark start = mark;
+            Mark start = CurrentPosition;
             Skip();
 
             // Create the FLOW-ENTRY token and append it to the queue.
 
-            tokens.Enqueue(new FlowEntry(start, mark));
+            tokens.Enqueue(new FlowEntry(start, CurrentPosition));
         }
 
         /// <summary>
@@ -938,11 +939,11 @@ namespace SharpYaml
 
                 if (!simpleKeyAllowed)
                 {
-                    throw new SyntaxErrorException(mark, mark, "Block sequence entries are not allowed in this context.");
+                    throw new SyntaxErrorException(CurrentPosition, CurrentPosition, "Block sequence entries are not allowed in this context.");
                 }
 
                 // Add the BLOCK-SEQUENCE-START token if needed.
-                RollIndent(mark.Column, -1, true, mark);
+                RollIndent(column, -1, true, CurrentPosition);
             }
             else
             {
@@ -961,12 +962,12 @@ namespace SharpYaml
 
             // Consume the token.
 
-            Mark start = mark;
+            Mark start = CurrentPosition;
             Skip();
 
             // Create the BLOCK-ENTRY token and append it to the queue.
 
-            tokens.Enqueue(new BlockEntry(start, mark));
+            tokens.Enqueue(new BlockEntry(start, CurrentPosition));
         }
 
         /// <summary>
@@ -982,12 +983,12 @@ namespace SharpYaml
 
                 if (!simpleKeyAllowed)
                 {
-                    throw new SyntaxErrorException(mark, mark, "Mapping keys are not allowed in this context.");
+                    throw new SyntaxErrorException(CurrentPosition, CurrentPosition, "Mapping keys are not allowed in this context.");
                 }
 
                 // Add the BLOCK-MAPPING-START token if needed.
 
-                RollIndent(mark.Column, -1, false, mark);
+                RollIndent(column, -1, false, CurrentPosition);
             }
 
             // Reset any potential simple keys on the current flow level.
@@ -1000,12 +1001,12 @@ namespace SharpYaml
 
             // Consume the token.
 
-            Mark start = mark;
+            Mark start = CurrentPosition;
             Skip();
 
             // Create the KEY token and append it to the queue.
 
-            tokens.Enqueue(new Key(start, mark));
+            tokens.Enqueue(new Key(start, CurrentPosition));
         }
 
         /// <summary>
@@ -1047,12 +1048,12 @@ namespace SharpYaml
 
                     if (!simpleKeyAllowed)
                     {
-                        throw new SyntaxErrorException(mark, mark, "Mapping values are not allowed in this context.");
+                        throw new SyntaxErrorException(CurrentPosition, CurrentPosition, "Mapping values are not allowed in this context.");
                     }
 
                     // Add the BLOCK-MAPPING-START token if needed.
 
-                    RollIndent(mark.Column, -1, false, mark);
+                    RollIndent(column, -1, false, CurrentPosition);
                 }
 
                 // Simple keys after ':' are allowed in the block context.
@@ -1062,12 +1063,12 @@ namespace SharpYaml
 
             // Consume the token.
 
-            Mark start = mark;
+            Mark start = CurrentPosition;
             Skip();
 
             // Create the VALUE token and append it to the queue.
 
-            tokens.Enqueue(new Value(start, mark));
+            tokens.Enqueue(new Value(start, CurrentPosition));
         }
 
         /// <summary>
@@ -1139,7 +1140,7 @@ namespace SharpYaml
         {
             // Eat the indicator character.
 
-            Mark start = mark;
+            Mark start = CurrentPosition;
 
             Skip();
 
@@ -1160,18 +1161,18 @@ namespace SharpYaml
 
             if (value.Length == 0 || !(analyzer.IsBlankOrBreakOrZero() || analyzer.Check("?:,]}%@`")))
             {
-                throw new SyntaxErrorException(start, mark, "While scanning an anchor or alias, did not find expected alphabetic or numeric character.");
+                throw new SyntaxErrorException(start, CurrentPosition, "While scanning an anchor or alias, did not find expected alphabetic or numeric character.");
             }
 
             // Create a token.
 
             if (isAlias)
             {
-                return new AnchorAlias(value.ToString(), start, mark);
+                return new AnchorAlias(value.ToString(), start, CurrentPosition);
             }
             else
             {
-                return new Anchor(value.ToString(), start, mark);
+                return new Anchor(value.ToString(), start, CurrentPosition);
             }
         }
 
@@ -1198,7 +1199,7 @@ namespace SharpYaml
         /// </summary>
         Token ScanTag()
         {
-            Mark start = mark;
+            Mark start = CurrentPosition;
 
             // Check if the tag is in the canonical form.
 
@@ -1224,7 +1225,7 @@ namespace SharpYaml
 
                 if (!analyzer.Check('>'))
                 {
-                    throw new SyntaxErrorException(start, mark, "While scanning a tag, did not find the expected '>'.");
+                    throw new SyntaxErrorException(start, CurrentPosition, "While scanning a tag, did not find the expected '>'.");
                 }
 
                 Skip();
@@ -1274,12 +1275,12 @@ namespace SharpYaml
 
             if (!analyzer.IsBlankOrBreakOrZero())
             {
-                throw new SyntaxErrorException(start, mark, "While scanning a tag, did not find expected whitespace or line break.");
+                throw new SyntaxErrorException(start, CurrentPosition, "While scanning a tag, did not find expected whitespace or line break.");
             }
 
             // Create a token.
 
-            return new Tag(handle, suffix, start, mark);
+            return new Tag(handle, suffix, start, CurrentPosition);
         }
 
         /// <summary>
@@ -1316,7 +1317,7 @@ namespace SharpYaml
 
             // Eat the indicator '|' or '>'.
 
-            Mark start = mark;
+            Mark start = CurrentPosition;
 
             Skip();
 
@@ -1338,7 +1339,7 @@ namespace SharpYaml
 
                     if (analyzer.Check('0'))
                     {
-                        throw new SyntaxErrorException(start, mark, "While scanning a block scalar, find an intendation indicator equal to 0.");
+                        throw new SyntaxErrorException(start, CurrentPosition, "While scanning a block scalar, find an intendation indicator equal to 0.");
                     }
 
                     // Get the intendation level and eat the indicator.
@@ -1355,7 +1356,7 @@ namespace SharpYaml
             {
                 if (analyzer.Check('0'))
                 {
-                    throw new SyntaxErrorException(start, mark, "While scanning a block scalar, find an intendation indicator equal to 0.");
+                    throw new SyntaxErrorException(start, CurrentPosition, "While scanning a block scalar, find an intendation indicator equal to 0.");
                 }
 
                 increment = analyzer.AsDigit();
@@ -1389,7 +1390,7 @@ namespace SharpYaml
 
             if (!analyzer.IsBreakOrZero())
             {
-                throw new SyntaxErrorException(start, mark, "While scanning a block scalar, did not find expected comment or line break.");
+                throw new SyntaxErrorException(start, CurrentPosition, "While scanning a block scalar, did not find expected comment or line break.");
             }
 
             // Eat a line break.
@@ -1399,7 +1400,7 @@ namespace SharpYaml
                 SkipLine();
             }
 
-            Mark end = mark;
+            Mark end = CurrentPosition;
 
             // Set the intendation level if it was specified.
 
@@ -1414,7 +1415,7 @@ namespace SharpYaml
 
             // Scan the block scalar content.
 
-            while (mark.Column == currentIndent && !analyzer.IsZero())
+            while (column == currentIndent && !analyzer.IsZero())
             {
                 // We are at the beginning of a non-empty line.
 
@@ -1492,7 +1493,7 @@ namespace SharpYaml
         {
             int maxIndent = 0;
 
-            end = mark;
+            end = CurrentPosition;
 
             // Eat the intendation spaces and line breaks.
 
@@ -1500,21 +1501,21 @@ namespace SharpYaml
             {
                 // Eat the intendation spaces.
 
-                while ((currentIndent == 0 || mark.Column < currentIndent) && analyzer.IsSpace())
+                while ((currentIndent == 0 || column < currentIndent) && analyzer.IsSpace())
                 {
                     Skip();
                 }
 
-                if (mark.Column > maxIndent)
+                if (column > maxIndent)
                 {
-                    maxIndent = mark.Column;
+                    maxIndent = column;
                 }
 
                 // Check for a tab character messing the intendation.
 
-                if ((currentIndent == 0 || mark.Column < currentIndent) && analyzer.IsTab())
+                if ((currentIndent == 0 || column < currentIndent) && analyzer.IsTab())
                 {
-                    throw new SyntaxErrorException(start, mark, "While scanning a block scalar, find a tab character where an intendation space is expected.");
+                    throw new SyntaxErrorException(start, CurrentPosition, "While scanning a block scalar, find a tab character where an intendation space is expected.");
                 }
 
                 // Have we find a non-empty line?
@@ -1528,7 +1529,7 @@ namespace SharpYaml
 
                 breaks.Append(ReadLine());
 
-                end = mark;
+                end = CurrentPosition;
             }
 
             // Determine the indentation level if needed.
@@ -1566,8 +1567,8 @@ namespace SharpYaml
         {
             // Eat the left quote.
 
-            Mark start = mark;
-            Mark end = mark;
+            Mark start = CurrentPosition;
+            Mark end = CurrentPosition;
 
             Skip();
 
@@ -1582,14 +1583,14 @@ namespace SharpYaml
 
                 if (IsDocumentIndicator())
                 {
-                    throw new SyntaxErrorException(start, mark, "While scanning a quoted scalar, find unexpected document indicator.");
+                    throw new SyntaxErrorException(start, CurrentPosition, "While scanning a quoted scalar, find unexpected document indicator.");
                 }
 
                 // Check for EOF.
 
                 if (analyzer.IsZero())
                 {
-                    throw new SyntaxErrorException(start, mark, "While scanning a quoted scalar, find unexpected end of stream.");
+                    throw new SyntaxErrorException(start, CurrentPosition, "While scanning a quoted scalar, find unexpected end of stream.");
                 }
 
                 // Consume non-blank characters.
@@ -1655,7 +1656,7 @@ namespace SharpYaml
                                 }
                                 else
                                 {
-                                    throw new SyntaxErrorException(start, mark, "While parsing a quoted scalar, find unknown escape character.");
+                                    throw new SyntaxErrorException(start, CurrentPosition, "While parsing a quoted scalar, find unknown escape character.");
                                 }
                                 break;
                         }
@@ -1675,7 +1676,7 @@ namespace SharpYaml
                             {
                                 if (!analyzer.IsHex(k))
                                 {
-                                    throw new SyntaxErrorException(start, mark, "While parsing a quoted scalar, did not find expected hexdecimal number.");
+                                    throw new SyntaxErrorException(start, CurrentPosition, "While parsing a quoted scalar, did not find expected hexdecimal number.");
                                 }
                                 character = (character << 4) + analyzer.AsHex(k);
                             }
@@ -1707,7 +1708,7 @@ namespace SharpYaml
                                 if (foundNextCharacter)
                                     scanScalarValue.Append(CharHelper.ConvertFromUtf32(CharHelper.ConvertToUtf32((char)character, (char)nextCharacter)));
                                 else
-                                    throw new SyntaxErrorException(start, mark, "While parsing a quoted scalar, find invalid Unicode character escape code.");
+                                    throw new SyntaxErrorException(start, CurrentPosition, "While parsing a quoted scalar, find invalid Unicode character escape code.");
                             } else 
                                 scanScalarValue.Append(CharHelper.ConvertFromUtf32(character));
 
@@ -1801,7 +1802,7 @@ namespace SharpYaml
             // Eat the right quote.
             Skip();
 
-            end = mark;
+            end = CurrentPosition;
             return new Scalar(scanScalarValue.ToString(), isSingleQuoted ? ScalarStyle.SingleQuoted : ScalarStyle.DoubleQuoted, start, end);
         }
 
@@ -1836,8 +1837,8 @@ namespace SharpYaml
             bool hasLeadingBlanks = false;
             int currentIndent = indent + 1;
 
-            Mark start = mark;
-            Mark end = mark;
+            Mark start = CurrentPosition;
+            Mark end = CurrentPosition;
 
             // Consume the content of the plain scalar.
 
@@ -1864,7 +1865,7 @@ namespace SharpYaml
 
                     if (flowLevel > 0 && analyzer.Check(':') && !analyzer.IsBlankOrBreakOrZero(1))
                     {
-                        throw new SyntaxErrorException(start, mark, "While scanning a plain scalar, find unexpected ':'.");
+                        throw new SyntaxErrorException(start, CurrentPosition, "While scanning a plain scalar, find unexpected ':'.");
                     }
 
                     // Check for indicators that may end a plain scalar.
@@ -1916,7 +1917,7 @@ namespace SharpYaml
 
                     value.Append(ReadCurrentCharacter());
 
-                    end = mark;
+                    end = CurrentPosition;
                 }
 
                 // Is it the end?
@@ -1934,9 +1935,9 @@ namespace SharpYaml
                     {
                         // Check for tab character that abuse intendation.
 
-                        if (hasLeadingBlanks && mark.Column < currentIndent && analyzer.IsTab())
+                        if (hasLeadingBlanks && column < currentIndent && analyzer.IsTab())
                         {
-                            throw new SyntaxErrorException(start, mark, "While scanning a plain scalar, find a tab character that violate intendation.");
+                            throw new SyntaxErrorException(start, CurrentPosition, "While scanning a plain scalar, find a tab character that violate intendation.");
                         }
 
                         // Consume a space or a tab character.
@@ -1974,7 +1975,7 @@ namespace SharpYaml
 
                 // Check intendation level.
 
-                if (flowLevel == 0 && mark.Column < currentIndent)
+                if (flowLevel == 0 && column < currentIndent)
                 {
                     break;
                 }
@@ -2036,14 +2037,14 @@ namespace SharpYaml
 
             if (name.Length == 0)
             {
-                throw new SyntaxErrorException(start, mark, "While scanning a directive, could not find expected directive name.");
+                throw new SyntaxErrorException(start, CurrentPosition, "While scanning a directive, could not find expected directive name.");
             }
 
             // Check for an blank character after the name.
 
             if (!analyzer.IsBlankOrBreakOrZero())
             {
-                throw new SyntaxErrorException(start, mark, "While scanning a directive, find unexpected non-alphabetical character.");
+                throw new SyntaxErrorException(start, CurrentPosition, "While scanning a directive, find unexpected non-alphabetical character.");
             }
 
             return name.ToString();
@@ -2078,7 +2079,7 @@ namespace SharpYaml
 
             if (!analyzer.Check('.'))
             {
-                throw new SyntaxErrorException(start, mark, "While scanning a %YAML directive, did not find expected digit or '.' character.");
+                throw new SyntaxErrorException(start, CurrentPosition, "While scanning a %YAML directive, did not find expected digit or '.' character.");
             }
 
             Skip();
@@ -2109,7 +2110,7 @@ namespace SharpYaml
 
             if (!analyzer.IsBlank())
             {
-                throw new SyntaxErrorException(start, mark, "While scanning a %TAG directive, did not find expected whitespace.");
+                throw new SyntaxErrorException(start, CurrentPosition, "While scanning a %TAG directive, did not find expected whitespace.");
             }
 
             SkipWhitespaces();
@@ -2122,7 +2123,7 @@ namespace SharpYaml
 
             if (!analyzer.IsBlankOrBreakOrZero())
             {
-                throw new SyntaxErrorException(start, mark, "While scanning a %TAG directive, did not find expected whitespace or line break.");
+                throw new SyntaxErrorException(start, CurrentPosition, "While scanning a %TAG directive, did not find expected whitespace or line break.");
             }
 
             return new TagDirective(handle, prefix, start, start);
@@ -2166,7 +2167,7 @@ namespace SharpYaml
 
             if (tag.Length == 0)
             {
-                throw new SyntaxErrorException(start, mark, "While parsing a tag, did not find expected tag URI.");
+                throw new SyntaxErrorException(start, CurrentPosition, "While parsing a tag, did not find expected tag URI.");
             }
 
             return tag.ToString();
@@ -2188,7 +2189,7 @@ namespace SharpYaml
 
                 if (!(analyzer.Check('%') && analyzer.IsHex(1) && analyzer.IsHex(2)))
                 {
-                    throw new SyntaxErrorException(start, mark, "While parsing a tag, did not find URI escaped octet.");
+                    throw new SyntaxErrorException(start, CurrentPosition, "While parsing a tag, did not find URI escaped octet.");
                 }
 
                 // Get the octet.
@@ -2206,7 +2207,7 @@ namespace SharpYaml
 
                     if (width == 0)
                     {
-                        throw new SyntaxErrorException(start, mark, "While parsing a tag, find an incorrect leading UTF-8 octet.");
+                        throw new SyntaxErrorException(start, CurrentPosition, "While parsing a tag, find an incorrect leading UTF-8 octet.");
                     }
 
                     charBytes = new byte[width];
@@ -2217,7 +2218,7 @@ namespace SharpYaml
 
                     if ((octet & 0xC0) != 0x80)
                     {
-                        throw new SyntaxErrorException(start, mark, "While parsing a tag, find an incorrect trailing UTF-8 octet.");
+                        throw new SyntaxErrorException(start, CurrentPosition, "While parsing a tag, find an incorrect trailing UTF-8 octet.");
                     }
                 }
 
@@ -2232,7 +2233,7 @@ namespace SharpYaml
 
             if (str.Length == 0 || str.Length > 2)
             {
-                throw new SyntaxErrorException(start, mark, "While parsing a tag, find an incorrect UTF-8 sequence.");
+                throw new SyntaxErrorException(start, CurrentPosition, "While parsing a tag, find an incorrect UTF-8 sequence.");
             }
 
             return str;
@@ -2247,7 +2248,7 @@ namespace SharpYaml
 
             if (!analyzer.Check('!'))
             {
-                throw new SyntaxErrorException(start, mark, "While scanning a tag, did not find expected '!'.");
+                throw new SyntaxErrorException(start, CurrentPosition, "While scanning a tag, did not find expected '!'.");
             }
 
             // Copy the '!' character.
@@ -2277,7 +2278,7 @@ namespace SharpYaml
 
                 if (isDirective && (tagHandle.Length != 1 || tagHandle[0] != '!'))
                 {
-                    throw new SyntaxErrorException(start, mark, "While parsing a tag directive, did not find expected '!'.");
+                    throw new SyntaxErrorException(start, CurrentPosition, "While parsing a tag directive, did not find expected '!'.");
                 }
             }
 
@@ -2306,7 +2307,7 @@ namespace SharpYaml
 
                 if (++length > MaxVersionNumberLength)
                 {
-                    throw new SyntaxErrorException(start, mark, "While scanning a %YAML directive, find extremely long version number.");
+                    throw new SyntaxErrorException(start, CurrentPosition, "While scanning a %YAML directive, find extremely long version number.");
                 }
 
                 value = value*10 + analyzer.AsDigit();
@@ -2318,7 +2319,7 @@ namespace SharpYaml
 
             if (length == 0)
             {
-                throw new SyntaxErrorException(start, mark, "While scanning a %YAML directive, did not find expected version number.");
+                throw new SyntaxErrorException(start, CurrentPosition, "While scanning a %YAML directive, did not find expected version number.");
             }
 
             return value;
@@ -2335,7 +2336,7 @@ namespace SharpYaml
             // level.
 
 
-            bool isRequired = (flowLevel == 0 && indent == mark.Column);
+            bool isRequired = (flowLevel == 0 && indent == column);
 
 
             // A simple key is required only when it is the first token in the current
@@ -2350,7 +2351,7 @@ namespace SharpYaml
 
             if (simpleKeyAllowed)
             {
-                SimpleKey key = new SimpleKey(true, isRequired, tokensParsed + tokens.Count, mark);
+                SimpleKey key = new SimpleKey(true, isRequired, tokensParsed + tokens.Count, CurrentPosition);
 
                 RemoveSimpleKey();
 

--- a/src/SharpYaml/Serialization/Serializer.cs
+++ b/src/SharpYaml/Serialization/Serializer.cs
@@ -306,7 +306,7 @@ namespace SharpYaml.Serialization
         {
             if (reader == null)
                 throw new ArgumentNullException("reader");
-            return Deserialize(new EventReader(new Parser(reader)), expectedType, existingObject, contextSettings);
+            return Deserialize(new EventReader(Parser.CreateParser(reader)), expectedType, existingObject, contextSettings);
         }
 
         /// <summary>
@@ -323,7 +323,7 @@ namespace SharpYaml.Serialization
         {
             if (reader == null)
                 throw new ArgumentNullException("reader");
-            return Deserialize(new EventReader(new Parser(reader)), expectedType, existingObject, contextSettings, out context);
+            return Deserialize(new EventReader(Parser.CreateParser(reader)), expectedType, existingObject, contextSettings, out context);
         }
 
         /// <summary>

--- a/src/SharpYaml/Serialization/YamlStream.cs
+++ b/src/SharpYaml/Serialization/YamlStream.cs
@@ -106,7 +106,7 @@ namespace SharpYaml.Serialization
         {
             documents.Clear();
 
-            var parser = new Parser(input);
+            var parser = Parser.CreateParser(input);
 
             EventReader events = new EventReader(parser);
             events.Expect<StreamStart>();

--- a/src/SharpYaml/StringLookAheadBuffer.cs
+++ b/src/SharpYaml/StringLookAheadBuffer.cs
@@ -82,5 +82,7 @@ namespace SharpYaml
             }
             currentIndex += length;
         }
+
+        public void Cache(int length) { }
     }
 }


### PR DESCRIPTION
Performance improvement to use StringLookaheadBuffer where a string can be directly accessed. This proves important especially with YAML that has a lot of quoted values that makes heavy use of ScanFlowScalar.

This is a before and after comparison in DotTrace using Sample mode:
![image](https://user-images.githubusercontent.com/13626626/123160098-c9e02100-d43b-11eb-8303-a8da1bd6e716.png)

This is using Tracing mode:
![image](https://user-images.githubusercontent.com/13626626/123160778-9225a900-d43c-11eb-959e-d696c2043c2f.png)
