### PR TITLE
Remove dependency on System.Reflection.TypeExtensions from netstandad2.0

### DIFF
--- a/src/SharpYaml/SharpYaml.csproj
+++ b/src/SharpYaml/SharpYaml.csproj
@@ -42,10 +42,6 @@
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
-  </ItemGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <NoWarn>CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
This dependency isn't necessary for NS2, as noted by @xoofx in #54.

Fixes #54 and also makes it usable under MSBuild when targeting NS2 :)