### PR TITLE
Add option to serializer settings to ignore null values

### DIFF
--- a/src/SharpYaml.Tests/Serialization/SerializationTests2.cs
+++ b/src/SharpYaml.Tests/Serialization/SerializationTests2.cs
@@ -1543,6 +1543,36 @@ Test: !ClassWithImplicitMemberTypeInner
             public string String { get; set; }
         }
 
+        [Test]
+        public void TestIgnoreNulls()
+        {
+            var serializer = new Serializer();
+            serializer.Settings.IgnoreNulls = true;
+            var testObject = new ClassToIgnoreNulls()
+            {
+                Id = 10,
+                Nullable = 3,
+            };
+
+            var text = serializer.Serialize(testObject);
+            Assert.False(text.Contains("Name: null"));
+
+            var deserialized = serializer.Deserialize(new StringReader(text)) as ClassToIgnoreNulls;
+            Assert.NotNull(deserialized);
+            Assert.AreEqual(testObject.Id, deserialized.Id);
+            Assert.Null(deserialized.DontSerializeWhenNull);
+            Assert.AreEqual(testObject.Nullable, deserialized.Nullable);
+        }
+
+        public class ClassToIgnoreNulls
+        {
+            public int Id { get; set; }
+
+            public string DontSerializeWhenNull { get; set; }
+
+            public int? Nullable { get; set; }
+        }
+
         private void SerialRoundTrip(SerializerSettings settings, string text, Type serializedType = null)
         {
             var serializer = new Serializer(settings);

--- a/src/SharpYaml.Tests/Serialization/SerializationTests2.cs
+++ b/src/SharpYaml.Tests/Serialization/SerializationTests2.cs
@@ -1555,7 +1555,7 @@ Test: !ClassWithImplicitMemberTypeInner
             };
 
             var text = serializer.Serialize(testObject);
-            Assert.False(text.Contains("Name: null"));
+            Assert.False(text.Contains("DontSerializeWhenNull: null"));
 
             var deserialized = serializer.Deserialize(new StringReader(text)) as ClassToIgnoreNulls;
             Assert.NotNull(deserialized);

--- a/src/SharpYaml/Serialization/SerializerSettings.cs
+++ b/src/SharpYaml/Serialization/SerializerSettings.cs
@@ -196,6 +196,11 @@ namespace SharpYaml.Serialization
         public bool RespectPrivateSetters { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to ignore serialization of properties with null values. Default is false.
+        /// </summary>
+        public bool IgnoreNulls { get; set; }
+
+        /// <summary>
         /// Gets or sets the default key comparer used to sort members (<see cref="IMemberDescriptor"/>) or
         /// dictionary keys, when serializing objects as YAML mappings. Default is <see cref="DefaultKeyComparer"/>. 
         /// To disable the default comparer, this value can be set to null.

--- a/src/SharpYaml/Serialization/Serializers/ObjectSerializer.cs
+++ b/src/SharpYaml/Serialization/Serializers/ObjectSerializer.cs
@@ -406,10 +406,13 @@ namespace SharpYaml.Serialization.Serializers
             if (!member.ShouldSerialize(objectContext.Instance))
                 return;
 
+            var memberValue = member.Get(objectContext.Instance);
+            if (memberValue == null && objectContext.Settings.IgnoreNulls)
+                return;
+
             // Emit the key name
             WriteMemberName(ref objectContext, member, member.Name);
 
-            var memberValue = member.Get(objectContext.Instance);
             var memberType = member.Type;
 
             // In case of serializing a property/field which is not writeable


### PR DESCRIPTION
Adding a optional setting for serializer to ignore serialization of properties with null values.