### PR TITLE
Code cleanup

### DIFF
--- a/src/SharpYaml/CharHelper.cs
+++ b/src/SharpYaml/CharHelper.cs
@@ -65,33 +65,9 @@ namespace SharpYaml
             return (((highSurrogate - HIGH_SURROGATE_START) * 0x400) + (lowSurrogate - LOW_SURROGATE_START) + UNICODE_PLANE01_START);
         }
 
-        public static unsafe string ConvertFromUtf32(int utf32)
+        public static string ConvertFromUtf32(int utf32)
         {
-#if PROFILE328
-            // For UTF32 values from U+00D800 ~ U+00DFFF, we should throw.  They 
-            // are considered as irregular code unit sequence, but they are not illegal.
-            if ((utf32 < 0 || utf32 > UNICODE_PLANE16_END) || (utf32 >= HIGH_SURROGATE_START && utf32 <= LOW_SURROGATE_END))
-            {
-                throw new ArgumentOutOfRangeException("utf32", "InvalidUTF32");
-            }
-
-            if (utf32 < UNICODE_PLANE01_START)
-            {
-                // This is a BMP character. 
-                return Char.ToString((char)utf32);
-            }
-            unsafe
-            {
-                // This is a supplementary character.  Convert it to a surrogate pair in UTF-16.
-                utf32 -= UNICODE_PLANE01_START;
-                var address = new char[2];
-                address[0] = (char)((utf32 / 0x400) + (int) HIGH_SURROGATE_START);
-                address[1] = (char)((utf32 % 0x400) + (int) LOW_SURROGATE_START);
-                return new string(address, 0, 2);
-            }
-#else
             return char.ConvertFromUtf32(utf32);
-#endif
         }
     }
 }

--- a/src/SharpYaml/Model/YamlNodeTracker.cs
+++ b/src/SharpYaml/Model/YamlNodeTracker.cs
@@ -359,11 +359,7 @@ namespace SharpYaml.Model {
             }
         }
 
-#if NET35
-        Dictionary<YamlNode, ICollection<ParentAndIndex>> parents = new Dictionary<YamlNode, ICollection<ParentAndIndex>>();
-#else
         private ConditionalWeakTable<YamlNode, ICollection<ParentAndIndex>> parents = new ConditionalWeakTable<YamlNode, ICollection<ParentAndIndex>>();
-#endif
 
         void AddChild(YamlNode child, YamlNode parent, ChildIndex relationship) {
             var pi = new ParentAndIndex(parent, relationship);

--- a/src/SharpYaml/Serialization/AssemblyRegistry.cs
+++ b/src/SharpYaml/Serialization/AssemblyRegistry.cs
@@ -104,7 +104,7 @@ namespace SharpYaml.Serialization
             {
                 lookupAssemblies.Add(assembly);
 
-                var types = new Type[0];
+                var types = Array.Empty<Type>();
 
                 // Register all tags automatically.
                 foreach (var type in assembly.GetTypes())

--- a/src/SharpYaml/Serialization/DefaultObjectFactory.cs
+++ b/src/SharpYaml/Serialization/DefaultObjectFactory.cs
@@ -56,7 +56,7 @@ namespace SharpYaml.Serialization
     /// </summary>
     public sealed class DefaultObjectFactory : IObjectFactory
     {
-        private static readonly Type[] EmptyTypes = new Type[0];
+        private static readonly Type[] EmptyTypes = Array.Empty<Type>();
 
         private static readonly Dictionary<Type, Type> DefaultInterfaceImplementations = new Dictionary<Type, Type>
         {

--- a/src/SharpYaml/Serialization/Descriptors/ObjectDescriptor.cs
+++ b/src/SharpYaml/Serialization/Descriptors/ObjectDescriptor.cs
@@ -62,7 +62,7 @@ namespace SharpYaml.Serialization.Descriptors
 
         protected static readonly string SystemCollectionsNamespace = typeof(int).Namespace;
 
-        private readonly static object[] EmptyObjectArray = new object[0];
+        private readonly static object[] EmptyObjectArray = Array.Empty<object>();
         private readonly Type type;
         private List<IMemberDescriptor> members;
         private Dictionary<string, IMemberDescriptor> mapMembers;
@@ -258,10 +258,7 @@ namespace SharpYaml.Serialization.Descriptors
             }
 
             // Allow to add dynamic members per type
-            if (AttributeRegistry.PrepareMembersCallback != null)
-            {
-                AttributeRegistry.PrepareMembersCallback(this, memberList);
-            }
+            AttributeRegistry.PrepareMembersCallback?.Invoke(this, memberList);
 
             return memberList;
         }
@@ -389,7 +386,7 @@ namespace SharpYaml.Serialization.Descriptors
             if (defaultValueAttribute != null && member.ShouldSerialize == null && !emitDefaultValues)
             {
                 object defaultValue = defaultValueAttribute.Value;
-                Type defaultType = defaultValue == null ? null : defaultValue.GetType();
+                Type defaultType = defaultValue?.GetType();
                 if (defaultType.IsNumeric() && defaultType != memberType)
                     defaultValue = memberType.CastToNumericType(defaultValue);
                 member.ShouldSerialize = obj => !TypeExtensions.AreEqual(defaultValue, member.Get(obj));

--- a/src/SharpYaml/Serialization/Serializers/PrimitiveSerializer.cs
+++ b/src/SharpYaml/Serialization/Serializers/PrimitiveSerializer.cs
@@ -106,19 +106,11 @@ namespace SharpYaml.Serialization.Serializers
 
             if (type == typeof(TimeSpan))
             {
-#if NET35
-                return TimeSpan.Parse(text);
-#else
                 return TimeSpan.Parse(text, CultureInfo.InvariantCulture);
-#endif
             }
             else if (type == typeof(DateTimeOffset))
             {
-#if NET35
-                return DateTimeOffset.Parse(text);
-#else
                 return DateTimeOffset.Parse(text, CultureInfo.InvariantCulture);
-#endif
             }
             else if (type == typeof(Guid))
             {
@@ -282,19 +274,11 @@ namespace SharpYaml.Serialization.Serializers
                     default:
                         if (valueType == typeof(TimeSpan))
                         {
-#if NET35
-                            text = string.Format("{0:G}",((TimeSpan) value));
-#else
                             text = ((TimeSpan) value).ToString("G", CultureInfo.InvariantCulture);
-#endif
                         }
                         else if (valueType == typeof(DateTimeOffset))
                         {
-#if NET35
-                            text = string.Format("{0:o}", ((DateTimeOffset) value));
-#else
                             text = ((DateTimeOffset) value).ToString("o", CultureInfo.InvariantCulture);
-#endif
                         }
                         else if (valueType == typeof(Guid))
                         {

--- a/src/SharpYaml/SharpYaml.csproj
+++ b/src/SharpYaml/SharpYaml.csproj
@@ -13,7 +13,6 @@
     <PackageTags>yaml;parser;yml</PackageTags>
     <PackageProjectUrl>https://github.com/xoofx/SharpYaml</PackageProjectUrl>
     <PackageLicenseExpression>BSD-2-Clause</PackageLicenseExpression>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <!--Add support for sourcelink-->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/SharpYaml/TypeExtensions.cs
+++ b/src/SharpYaml/TypeExtensions.cs
@@ -54,56 +54,9 @@ namespace SharpYaml
 {
     internal static class TypeExtensions
     {
-#if !NETPOST45
-        public static Type GetTypeInfo(this Type type)
-        {
-            return type;
-        }
-#endif
-
         public static TypeCode GetTypeCode(this Type type)
         {
-#if !NETSTANDARD1_3
             return Type.GetTypeCode(type);
-#else
-            if (type == null)
-                return TypeCode.Empty;
-            if (type.GetTypeInfo().IsEnum)
-                type = Enum.GetUnderlyingType(type);
-
-            if (type == typeof(bool))
-                return TypeCode.Boolean;
-            if (type == typeof(char))
-                return TypeCode.Char;
-            if (type == typeof(sbyte))
-                return TypeCode.SByte;
-            if (type == typeof(byte))
-                return TypeCode.Byte;
-            if (type == typeof(short))
-                return TypeCode.Int16;
-            if (type == typeof(ushort))
-                return TypeCode.UInt16;
-            if (type == typeof(int))
-                return TypeCode.Int32;
-            if (type == typeof(uint))
-                return TypeCode.UInt32;
-            if (type == typeof(long))
-                return TypeCode.Int64;
-            if (type == typeof(ulong))
-                return TypeCode.UInt64;
-            if (type == typeof(float))
-                return TypeCode.Single;
-            if (type == typeof(double))
-                return TypeCode.Double;
-            if (type == typeof(decimal))
-                return TypeCode.Decimal;
-            if (type == typeof(DateTime))
-                return TypeCode.DateTime;
-            if (type == typeof(string))
-                return TypeCode.String;
-
-            return TypeCode.Object;
-#endif
         }
 
         private static Dictionary<Type, bool> anonymousTypes = new Dictionary<Type, bool>();


### PR DESCRIPTION
- Remove old code older than .netstandard2.0
- Make use of `Array.Empty()`.
- Simplify null calls.