### PR TITLE
Fix tests

### DIFF
--- a/src/SharpYaml.Tests/EmitterTests.cs
+++ b/src/SharpYaml.Tests/EmitterTests.cs
@@ -56,6 +56,12 @@ namespace SharpYaml.Tests
 {
     public class EmitterTests : YamlTest
     {
+        public EmitterTests()
+        {
+#if NETCOREAPP
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+#endif
+        }
         [Test]
         public void EmitExample1()
         {
@@ -140,7 +146,6 @@ namespace SharpYaml.Tests
             ParseAndEmit("test14.yaml");
         }
 
-#if NET45
         [Test]
         public void EmitUnicode()
         {
@@ -158,7 +163,6 @@ namespace SharpYaml.Tests
             var result = encoding.GetString(stream.ToArray()).Trim();
             Assert.AreEqual("'" + input + "'", result);
         }
-#endif
 
         [Test]
         public void EmitUnicodeEscapes()

--- a/src/SharpYaml.Tests/Serialization/SerializationTests.cs
+++ b/src/SharpYaml.Tests/Serialization/SerializationTests.cs
@@ -313,26 +313,23 @@ namespace SharpYaml.Tests.Serialization
             Assert.AreEqual("three", array[2]);
         }
 
-#if NET45
-
         [Test]
         public void Enums()
         {
             var settings = new SerializerSettings();
-            settings.RegisterAssembly(typeof(StringFormatFlags).Assembly);
+            settings.RegisterAssembly(typeof(BindingFlags).Assembly);
             var serializer = new Serializer(settings);
 
-            var flags = StringFormatFlags.NoClip | StringFormatFlags.NoFontFallback;
+            var flags = BindingFlags.Public | BindingFlags.InvokeMethod;
 
             var buffer = new StringWriter();
             serializer.Serialize(buffer, flags);
 
             var bufferAsText = buffer.ToString();
-            var deserialized = (StringFormatFlags) serializer.Deserialize(bufferAsText, typeof(StringFormatFlags));
+            var deserialized = (BindingFlags) serializer.Deserialize(bufferAsText, typeof(BindingFlags));
 
             Assert.AreEqual(flags, deserialized);
         }
-#endif
 
         [Test]
         public void CustomTags()


### PR DESCRIPTION
The following tests can be run on .net6.0.
- `EmitterTests.EmitUnicode()`
- `SerializationTests.Enums()`