### PR TITLE
Tag type names in payloads are no longer respected by default.

### DIFF
--- a/src/SharpYaml.Tests/Serialization/SerializationTests.cs
+++ b/src/SharpYaml.Tests/Serialization/SerializationTests.cs
@@ -180,16 +180,22 @@ namespace SharpYaml.Tests.Serialization
         }
 
         [Test]
-        public void DeserializeExplicitType()
+        public void DeserializeUnsafeExplicitType()
         {
-            var settings = new SerializerSettings();
-            settings.RegisterAssembly(typeof(SerializationTests).Assembly);
-
-            var serializer = new Serializer();
+            var settings = new SerializerSettings(){ UnsafeAllowDeserializeFromTagTypeName = true };
+            var serializer = new Serializer(settings);
             object result = serializer.Deserialize(YamlFile("explicitType.yaml"), typeof(object));
 
             Assert.True(typeof(Z).IsAssignableFrom(result.GetType()));
             Assert.AreEqual("bbb", ((Z)result).aaa);
+        }
+
+        [Test]
+        public void DeserializeUnregisterdExplicitType()
+        {
+            var serializer = new Serializer();
+
+            Assert.Throws<YamlException>(() => serializer.Deserialize(YamlFile("explicitType.yaml"), typeof(object)));
         }
 
         [Test]
@@ -206,9 +212,9 @@ namespace SharpYaml.Tests.Serialization
         }
 
         [Test]
-        public void DeserializeExplicitDictionary()
+        public void DeserializeUnsafeExplicitDictionary()
         {
-            var serializer = new Serializer();
+            var serializer = new Serializer(new SerializerSettings { UnsafeAllowDeserializeFromTagTypeName = true });
             object result = serializer.Deserialize(YamlFile("dictionaryExplicit.yaml"));
 
             Assert.True(typeof(IDictionary<string, int>).IsAssignableFrom(result.GetType()), "The deserialized object has the wrong type.");
@@ -218,6 +224,13 @@ namespace SharpYaml.Tests.Serialization
             Assert.AreEqual(2, dictionary["key2"]);
         }
 
+        [Test]
+        public void DeserializeUnregisterdExplicitDictionary()
+        {
+            var serializer = new Serializer();
+            Assert.Throws<YamlException>(() => serializer.Deserialize(YamlFile("dictionaryExplicit.yaml")));
+        }
+        
         [Test]
         public void DeserializeListOfDictionaries()
         {
@@ -248,9 +261,9 @@ namespace SharpYaml.Tests.Serialization
         }
 
         [Test]
-        public void DeserializeExplicitList()
+        public void DeserializeUnsafeExplicitList()
         {
-            var serializer = new Serializer();
+            var serializer = new Serializer(new SerializerSettings { UnsafeAllowDeserializeFromTagTypeName = true });
             var result = serializer.Deserialize(YamlFile("listExplicit.yaml"));
 
             Assert.True(typeof(IList<int>).IsAssignableFrom(result.GetType()));
@@ -259,6 +272,13 @@ namespace SharpYaml.Tests.Serialization
             Assert.AreEqual(3, list[0]);
             Assert.AreEqual(4, list[1]);
             Assert.AreEqual(5, list[2]);
+        }
+
+        [Test]
+        public void DeserializeUnregisterdExplicitList()
+        {
+            var serializer = new Serializer();
+            Assert.Throws<YamlException>(() => serializer.Deserialize(YamlFile("listExplicit.yaml")));
         }
 
         [Test]

--- a/src/SharpYaml.Tests/Serialization/SerializationTests2.cs
+++ b/src/SharpYaml.Tests/Serialization/SerializationTests2.cs
@@ -706,6 +706,8 @@ Value: 0
         {
             var settings = new SerializerSettings() { EmitTags = false };
             settings.RegisterTagMapping("ClassWithObjectAndScalar", typeof(ClassWithObjectAndScalar));
+            Assert.True(settings.EmitTags);
+            settings.EmitTags = false;
             var serializer = new Serializer(settings);
             var text = serializer.Serialize(new ClassWithObjectAndScalar { Value4 = new ClassWithObjectAndScalar() });
             Assert.False(text.Contains("!"));
@@ -885,6 +887,7 @@ Value: 0
         public void TestEmitShortTypeName()
         {
             var settings = new SerializerSettings() { EmitShortTypeName = true };
+            settings.RegisterAssembly(typeof(ClassWithObjectAndScalar).Assembly);
             SerialRoundTrip(settings, new ClassWithObjectAndScalar());
         }
 
@@ -899,6 +902,7 @@ Value: 0
         public void TestClassWithChars()
         {
             var settings = new SerializerSettings() { EmitShortTypeName = true };
+            settings.RegisterAssembly(typeof(ClassWithChars).Assembly);
             SerialRoundTrip(settings, new ClassWithChars()
             {
                 Start = ' ',
@@ -910,6 +914,7 @@ Value: 0
         public void TestClassWithSpecialChars()
         {
             var settings = new SerializerSettings() { EmitShortTypeName = true };
+            settings.RegisterAssembly(typeof(ClassWithObjectAndScalar).Assembly);
             for (int i = 0; i < 32; i++)
             {
                 SerialRoundTrip(settings, new ClassWithChars()
@@ -1554,7 +1559,7 @@ Test: !ClassWithImplicitMemberTypeInner
             var text = serializer.Serialize(testObject);
             Assert.False(text.Contains("DontSerializeWhenNull: null"));
 
-            var deserialized = serializer.Deserialize(new StringReader(text)) as ClassToIgnoreNulls;
+            var deserialized = serializer.Deserialize<ClassToIgnoreNulls>(new StringReader(text));
             Assert.NotNull(deserialized);
             Assert.AreEqual(testObject.Id, deserialized.Id);
             Assert.Null(deserialized.DontSerializeWhenNull);

--- a/src/SharpYaml.Tests/YamlNodeTest.cs
+++ b/src/SharpYaml.Tests/YamlNodeTest.cs
@@ -189,7 +189,7 @@ namespace SharpYaml.Tests
         }
 
         [Test]
-        public void TagTest()
+        public void UnsafeTagTest()
         {
             var file = System.Reflection.Assembly.GetExecutingAssembly()
                 .GetManifestResourceStream("SharpYaml.Tests.files.dictionaryExplicit.yaml");
@@ -197,14 +197,15 @@ namespace SharpYaml.Tests
             var fileStream = new StreamReader(file);
             var stream = YamlStream.Load(fileStream);
 
-            var dict = stream[0].Contents.ToObject<object>();
+            var settings = new SerializerSettings() { UnsafeAllowDeserializeFromTagTypeName = true };
+            var dict = stream[0].Contents.ToObject<object>(settings);
 
             Assert.AreEqual(typeof(Dictionary<string, int>), dict.GetType());
             Assert.AreEqual("!System.Collections.Generic.Dictionary`2[System.String,System.Int32],mscorlib", stream[0].Contents.Tag);
 
             stream[0].Contents.Tag = "!System.Collections.Generic.Dictionary`2[System.String,System.Double],mscorlib";
 
-            var dict2 = stream[0].Contents.ToObject<object>();
+            var dict2 = stream[0].Contents.ToObject<object>(settings);
 
             Assert.AreEqual(typeof(Dictionary<string, double>), dict2.GetType());
         }

--- a/src/SharpYaml/Serialization/SerializerSettings.cs
+++ b/src/SharpYaml/Serialization/SerializerSettings.cs
@@ -83,7 +83,6 @@ namespace SharpYaml.Serialization
             PreferredIndent = 2;
             IndentLess = false;
             EmitAlias = true;
-            EmitTags = true;
             SortKeyForMapping = true;
             EmitJsonCompatible = false;
             EmitCapacityForList = false;
@@ -131,10 +130,10 @@ namespace SharpYaml.Serialization
         public bool EmitAlias { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to emit tags when serializing. Default is true.
+        /// Gets or sets a value indicating whether to emit tags when serializing. Default is false.
         /// </summary>
         /// <value><c>true</c> to emit tags when serializing; otherwise, <c>false</c>.</value>
-        public bool EmitTags { get; set; }
+        public bool EmitTags { get; set; } = false;
 
         /// <summary>
         /// Gets or sets a value indicating whether the identation is trying to less
@@ -228,6 +227,16 @@ namespace SharpYaml.Serialization
                     throw new ArgumentNullException("value");
                 _namingConvention = value;
             }
+        }
+
+        /// <summary>
+        /// If set to <c>true</c>, Deserialize using unregistered type names contained in YAML.
+        /// <b>This should be set up carefully as vulnerabilities can occur.</b>
+        /// </summary>
+        public bool UnsafeAllowDeserializeFromTagTypeName
+        {
+            get => AssemblyRegistry.UnsafeAllowDeserializeFromTagTypeName;
+            set => AssemblyRegistry.UnsafeAllowDeserializeFromTagTypeName = value;
         }
 
         /// <summary>
@@ -340,15 +349,18 @@ namespace SharpYaml.Serialization
 
         /// <summary>
         /// Register a mapping between a tag and a type.
+        /// When this method is called, <c>EmitTags</c> is then set to true.
         /// </summary>
         /// <param name="assembly">The assembly.</param>
         public void RegisterAssembly(Assembly assembly)
         {
             AssemblyRegistry.RegisterAssembly(assembly, attributeRegistry);
+            EmitTags = true;
         }
 
         /// <summary>
         /// Register a mapping between a tag and a type.
+        /// When this method is called, <c>EmitTags</c> is then set to true.
         /// </summary>
         /// <param name="tagName">Name of the tag.</param>
         /// <param name="tagType">Type of the tag.</param>
@@ -356,6 +368,7 @@ namespace SharpYaml.Serialization
         public void RegisterTagMapping(string tagName, Type tagType, bool isAlias = false)
         {
             AssemblyRegistry.RegisterTagMapping(tagName, tagType, isAlias);
+            EmitTags = true;
         }
 
         /// <summary>


### PR DESCRIPTION
- `SerializerSettings.UnsafeAllowDeserializeFromTagTypeName` is added.
- `SerializerSettings.EmitTags` is set to false by default. (for roundtrip)
- Calling `SerializerSettings.RegisterAssembly` or `SerializerSettings.RegisterTagMapping`, sets `EmitTags` to true.