### PR TITLE
Added named order constructor to YamlMemberAttribute.

### DIFF
--- a/src/SharpYaml/Serialization/YamlMemberAttribute.cs
+++ b/src/SharpYaml/Serialization/YamlMemberAttribute.cs
@@ -81,6 +81,17 @@ namespace SharpYaml.Serialization
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="YamlMemberAttribute"/> class.
+        /// </summary>
+        /// <param name="name">The name.</param>
+        /// <param name="order">The order.</param>
+        public YamlMemberAttribute(string name, int order)
+        {
+            this.Name = name;
+            this.Order = order;
+        }
+
+        /// <summary>
         /// Specify the way to store a property or field of some class or structure.
         /// </summary>
         /// <param name="name">The name.</param>


### PR DESCRIPTION
This PR adds a new constructor to YamlMemberAttribute that allows both name and order to be specified. Since DefaultKeyComparer already looks for Order.HasValue first and then falls back to Name, both can be specified on the same member.

This PR resolves #42 which did not allow Order to be specified as an attribute parameter since int? triggered a [CS0655 compiler error](https://docs.microsoft.com/en-us/dotnet/csharp/misc/cs0655).

I did verify that all tests still pass before submitting this pull requests.