### PR TITLE
Allow reuse of Serializer instance

### DIFF
--- a/src/SharpYaml/Serialization/Serializer.cs
+++ b/src/SharpYaml/Serialization/Serializer.cs
@@ -223,6 +223,11 @@ namespace SharpYaml.Serialization
             context.WriteYaml(graph, type);
             context.Writer.DocumentEnd();
             context.Writer.StreamEnd();
+
+            if (Settings.ResetAlias && ObjectSerializer is AnchorSerializer anchorSerializer)
+            {
+                anchorSerializer.Reset();
+            }
         }
 
         /// <summary>
@@ -533,6 +538,11 @@ namespace SharpYaml.Serialization
             if (hasStreamStart)
             {
                 reader.Expect<StreamEnd>();
+            }
+
+            if (Settings.ResetAlias && ObjectSerializer is AnchorSerializer anchorSerializer)
+            {
+                anchorSerializer.Reset();
             }
 
             return result;

--- a/src/SharpYaml/Serialization/SerializerSettings.cs
+++ b/src/SharpYaml/Serialization/SerializerSettings.cs
@@ -83,6 +83,7 @@ namespace SharpYaml.Serialization
             PreferredIndent = 2;
             IndentLess = false;
             EmitAlias = true;
+            ResetAlias = false;
             SortKeyForMapping = true;
             EmitJsonCompatible = false;
             EmitCapacityForList = false;
@@ -128,6 +129,12 @@ namespace SharpYaml.Serialization
         /// </summary>
         /// <value><c>true</c> to emit anchor alias; otherwise, <c>false</c>.</value>
         public bool EmitAlias { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to reset anchor alias in order to reuse <see cref="Serializer" /> instance. Default is true.
+        /// </summary>
+        /// <value><c>true</c> to reset anchor alias; otherwise, <c>false</c>.</value>
+        public bool ResetAlias { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to emit tags when serializing. Default is false.

--- a/src/SharpYaml/Serialization/SerializerSettings.cs
+++ b/src/SharpYaml/Serialization/SerializerSettings.cs
@@ -131,7 +131,7 @@ namespace SharpYaml.Serialization
         public bool EmitAlias { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to reset anchor alias in order to reuse <see cref="Serializer" /> instance. Default is true.
+        /// Gets or sets a value indicating whether to reset anchor alias in order to reuse <see cref="Serializer" /> instance. Default is false.
         /// </summary>
         /// <value><c>true</c> to reset anchor alias; otherwise, <c>false</c>.</value>
         public bool ResetAlias { get; set; }

--- a/src/SharpYaml/Serialization/Serializers/AnchorSerializer.cs
+++ b/src/SharpYaml/Serialization/Serializers/AnchorSerializer.cs
@@ -46,7 +46,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.Reflection;
 using SharpYaml.Events;
 
@@ -142,6 +141,12 @@ namespace SharpYaml.Serialization.Serializers
             }
 
             base.WriteYaml(ref objectContext);
+        }
+
+        public void Reset()
+        {
+            aliasToObject.Clear();
+            objectToAlias.Clear();
         }
     }
 }


### PR DESCRIPTION
Changes made according to the indications of https://github.com/xoofx/SharpYaml/issues/115#issuecomment-1206198558

The tests were not very clear where to put them since there are SerializationTests and SerializationTests2, if you have any suggestion and you want me to change it, let me know.