### PR TITLE
Suppress SHARPYAML002 when a converter handles the type

### DIFF
--- a/src/SharpYaml.SourceGenerator/YamlSerializerContextGenerator.cs
+++ b/src/SharpYaml.SourceGenerator/YamlSerializerContextGenerator.cs
@@ -407,10 +407,23 @@ public sealed class YamlSerializerContextGenerator : IIncrementalGenerator
                     continue;
                 }
 
+                // Skip if the member itself has [YamlConverter(typeof(...))] — the converter handles serialization.
+                if (GetYamlConverterAttributeTypeName(member) is not null)
+                {
+                    continue;
+                }
+
+                // Skip if the member type is handled by a converter (type-level attribute or context-level converter).
+                if (IsTypeHandledByConverter(memberType, model.SourceGenerationOptions.ConverterTypes, compilation))
+                {
+                    continue;
+                }
+
                 if (TryGetArrayElementType(memberType, out var arrayElementType) ||
                     TryGetSequenceElementType(memberType, out arrayElementType, out _))
                 {
-                    if (IsKnownScalar(arrayElementType) || indexByType.ContainsKey(arrayElementType))
+                    if (IsKnownScalar(arrayElementType) || indexByType.ContainsKey(arrayElementType) ||
+                        IsTypeHandledByConverter(arrayElementType, model.SourceGenerationOptions.ConverterTypes, compilation))
                     {
                         continue;
                     }
@@ -437,7 +450,8 @@ public sealed class YamlSerializerContextGenerator : IIncrementalGenerator
                         continue;
                     }
 
-                    if (IsKnownScalar(dictionaryValueType) || indexByType.ContainsKey(dictionaryValueType))
+                    if (IsKnownScalar(dictionaryValueType) || indexByType.ContainsKey(dictionaryValueType) ||
+                        IsTypeHandledByConverter(dictionaryValueType, model.SourceGenerationOptions.ConverterTypes, compilation))
                     {
                         continue;
                     }
@@ -5877,6 +5891,55 @@ public sealed class YamlSerializerContextGenerator : IIncrementalGenerator
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Checks whether the given type is handled by a converter — either via a [YamlConverter] attribute
+    /// on the type itself, or via a context-level YamlConverter&lt;T&gt; registration.
+    /// Nullable&lt;T&gt; value types are unwrapped before checking.
+    /// </summary>
+    private static bool IsTypeHandledByConverter(
+        ITypeSymbol typeToCheck,
+        ImmutableArray<ITypeSymbol> converterTypes,
+        Compilation compilation)
+    {
+        // Unwrap Nullable<T> for value types.
+        var unwrappedType = typeToCheck;
+        if (typeToCheck is INamedTypeSymbol nullable && nullable.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
+        {
+            unwrappedType = nullable.TypeArguments[0];
+        }
+
+        // Check if the type itself has [YamlConverter(typeof(...))].
+        if (GetYamlConverterAttributeTypeName(unwrappedType) is not null)
+        {
+            return true;
+        }
+
+        // Check if a context-level converter handles this type.
+        if (!converterTypes.IsDefaultOrEmpty)
+        {
+            var yamlConverterOfT = compilation.GetTypeByMetadataName("SharpYaml.Serialization.YamlConverter`1");
+            if (yamlConverterOfT is not null)
+            {
+                foreach (var converterType in converterTypes)
+                {
+                    // Walk up the base type chain looking for YamlConverter<T>.
+                    for (var current = converterType as INamedTypeSymbol; current is not null; current = current.BaseType)
+                    {
+                        if (current.IsGenericType &&
+                            SymbolEqualityComparer.Default.Equals(current.OriginalDefinition, yamlConverterOfT) &&
+                            current.TypeArguments.Length == 1 &&
+                            SymbolEqualityComparer.Default.Equals(current.TypeArguments[0], unwrappedType))
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+
+        return false;
     }
 
     private static ImmutableArray<ISymbol> GetSerializableMembers(INamedTypeSymbol type)

--- a/src/SharpYaml.Tests/Serialization/YamlSerializerContextGeneratorDiagnosticTests.cs
+++ b/src/SharpYaml.Tests/Serialization/YamlSerializerContextGeneratorDiagnosticTests.cs
@@ -147,6 +147,427 @@ public class YamlSerializerContextGeneratorDiagnosticTests
         StringAssert.Contains(result.GeneratedSource, "value is global::Dog");
     }
 
+    [TestMethod]
+    public void SHARPYAML002_IsSuppressed_WhenContextLevelConverterHandlesMemberType()
+    {
+        const string source = """
+            using SharpYaml.Serialization;
+
+            public sealed class CustomType
+            {
+                public string Value { get; set; } = string.Empty;
+            }
+
+            public sealed class CustomTypeConverter : YamlConverter<CustomType>
+            {
+                public override CustomType Read(YamlReader reader)
+                {
+                    var value = reader.GetScalarValue();
+                    reader.Read();
+                    return new CustomType { Value = value };
+                }
+
+                public override void Write(YamlWriter writer, CustomType value)
+                {
+                    writer.WriteScalar(value.Value);
+                }
+            }
+
+            public sealed class ModelWithCustomType
+            {
+                public CustomType? Item { get; set; }
+            }
+
+            [YamlSerializable(typeof(ModelWithCustomType))]
+            [YamlSourceGenerationOptions(Converters = [typeof(CustomTypeConverter)])]
+            internal partial class TestContext : YamlSerializerContext
+            {
+            }
+            """;
+
+        var result = RunGenerator(source);
+
+        var diagnostics = result.Diagnostics
+            .Where(static d => d.Id == "SHARPYAML002")
+            .ToArray();
+
+        Assert.AreEqual(0, diagnostics.Length, string.Join(Environment.NewLine, diagnostics.Select(static d => d.GetMessage())));
+    }
+
+    [TestMethod]
+    public void SHARPYAML002_IsSuppressed_WhenMemberHasYamlConverterAttribute()
+    {
+        const string source = """
+            using SharpYaml.Serialization;
+
+            public sealed class CustomType
+            {
+                public string Value { get; set; } = string.Empty;
+            }
+
+            public sealed class CustomTypeConverter : YamlConverter<CustomType>
+            {
+                public override CustomType Read(YamlReader reader)
+                {
+                    var value = reader.GetScalarValue();
+                    reader.Read();
+                    return new CustomType { Value = value };
+                }
+
+                public override void Write(YamlWriter writer, CustomType value)
+                {
+                    writer.WriteScalar(value.Value);
+                }
+            }
+
+            public sealed class ModelWithConverterOnMember
+            {
+                [YamlConverter(typeof(CustomTypeConverter))]
+                public CustomType? Item { get; set; }
+            }
+
+            [YamlSerializable(typeof(ModelWithConverterOnMember))]
+            internal partial class TestContext : YamlSerializerContext
+            {
+            }
+            """;
+
+        var result = RunGenerator(source);
+
+        var diagnostics = result.Diagnostics
+            .Where(static d => d.Id == "SHARPYAML002")
+            .ToArray();
+
+        Assert.AreEqual(0, diagnostics.Length, string.Join(Environment.NewLine, diagnostics.Select(static d => d.GetMessage())));
+    }
+
+    [TestMethod]
+    public void SHARPYAML002_IsSuppressed_WhenTypeHasYamlConverterAttribute()
+    {
+        const string source = """
+            using SharpYaml.Serialization;
+
+            public sealed class TypeLevelConverter : YamlConverter<ConverterDecoratedType>
+            {
+                public override ConverterDecoratedType Read(YamlReader reader)
+                {
+                    var value = reader.GetScalarValue();
+                    reader.Read();
+                    return new ConverterDecoratedType { Value = value };
+                }
+
+                public override void Write(YamlWriter writer, ConverterDecoratedType value)
+                {
+                    writer.WriteScalar(value.Value);
+                }
+            }
+
+            [YamlConverter(typeof(TypeLevelConverter))]
+            public sealed class ConverterDecoratedType
+            {
+                public string Value { get; set; } = string.Empty;
+            }
+
+            public sealed class ModelWithTypeLevelConverter
+            {
+                public ConverterDecoratedType? Item { get; set; }
+            }
+
+            [YamlSerializable(typeof(ModelWithTypeLevelConverter))]
+            internal partial class TestContext : YamlSerializerContext
+            {
+            }
+            """;
+
+        var result = RunGenerator(source);
+
+        var diagnostics = result.Diagnostics
+            .Where(static d => d.Id == "SHARPYAML002")
+            .ToArray();
+
+        Assert.AreEqual(0, diagnostics.Length, string.Join(Environment.NewLine, diagnostics.Select(static d => d.GetMessage())));
+    }
+
+    [TestMethod]
+    public void SHARPYAML002_IsSuppressed_WhenContextConverterHandlesArrayElementType()
+    {
+        const string source = """
+            using System.Collections.Generic;
+            using SharpYaml.Serialization;
+
+            public sealed class CustomType
+            {
+                public string Value { get; set; } = string.Empty;
+            }
+
+            public sealed class CustomTypeConverter : YamlConverter<CustomType>
+            {
+                public override CustomType Read(YamlReader reader)
+                {
+                    var value = reader.GetScalarValue();
+                    reader.Read();
+                    return new CustomType { Value = value };
+                }
+
+                public override void Write(YamlWriter writer, CustomType value)
+                {
+                    writer.WriteScalar(value.Value);
+                }
+            }
+
+            public sealed class ModelWithList
+            {
+                public List<CustomType>? Items { get; set; }
+            }
+
+            [YamlSerializable(typeof(ModelWithList))]
+            [YamlSourceGenerationOptions(Converters = [typeof(CustomTypeConverter)])]
+            internal partial class TestContext : YamlSerializerContext
+            {
+            }
+            """;
+
+        var result = RunGenerator(source);
+
+        var diagnostics = result.Diagnostics
+            .Where(static d => d.Id == "SHARPYAML002")
+            .ToArray();
+
+        Assert.AreEqual(0, diagnostics.Length, string.Join(Environment.NewLine, diagnostics.Select(static d => d.GetMessage())));
+    }
+
+    [TestMethod]
+    public void SHARPYAML002_IsSuppressed_WhenContextConverterHandlesDictionaryValueType()
+    {
+        const string source = """
+            using System.Collections.Generic;
+            using SharpYaml.Serialization;
+
+            public sealed class CustomType
+            {
+                public string Value { get; set; } = string.Empty;
+            }
+
+            public sealed class CustomTypeConverter : YamlConverter<CustomType>
+            {
+                public override CustomType Read(YamlReader reader)
+                {
+                    var value = reader.GetScalarValue();
+                    reader.Read();
+                    return new CustomType { Value = value };
+                }
+
+                public override void Write(YamlWriter writer, CustomType value)
+                {
+                    writer.WriteScalar(value.Value);
+                }
+            }
+
+            public sealed class ModelWithDictionary
+            {
+                public Dictionary<string, CustomType>? Items { get; set; }
+            }
+
+            [YamlSerializable(typeof(ModelWithDictionary))]
+            [YamlSourceGenerationOptions(Converters = [typeof(CustomTypeConverter)])]
+            internal partial class TestContext : YamlSerializerContext
+            {
+            }
+            """;
+
+        var result = RunGenerator(source);
+
+        var diagnostics = result.Diagnostics
+            .Where(static d => d.Id == "SHARPYAML002")
+            .ToArray();
+
+        Assert.AreEqual(0, diagnostics.Length, string.Join(Environment.NewLine, diagnostics.Select(static d => d.GetMessage())));
+    }
+
+    [TestMethod]
+    public void SHARPYAML002_StillFires_WhenNoConverterHandlesType()
+    {
+        const string source = """
+            using SharpYaml.Serialization;
+
+            public sealed class UnhandledType
+            {
+                public string Value { get; set; } = string.Empty;
+            }
+
+            public sealed class ModelWithUnhandledType
+            {
+                public UnhandledType? Item { get; set; }
+            }
+
+            [YamlSerializable(typeof(ModelWithUnhandledType))]
+            internal partial class TestContext : YamlSerializerContext
+            {
+            }
+            """;
+
+        var result = RunGenerator(source);
+
+        var diagnostics = result.Diagnostics
+            .Where(static d => d.Id == "SHARPYAML002")
+            .ToArray();
+
+        Assert.AreEqual(1, diagnostics.Length);
+        Assert.AreEqual(DiagnosticSeverity.Error, diagnostics[0].Severity);
+        StringAssert.Contains(diagnostics[0].GetMessage(), "UnhandledType");
+    }
+
+    [TestMethod]
+    public void SHARPYAML002_StillFires_WhenConverterHandlesDifferentType()
+    {
+        const string source = """
+            using SharpYaml.Serialization;
+
+            public sealed class TypeA
+            {
+                public string Value { get; set; } = string.Empty;
+            }
+
+            public sealed class TypeB
+            {
+                public string Value { get; set; } = string.Empty;
+            }
+
+            public sealed class TypeAConverter : YamlConverter<TypeA>
+            {
+                public override TypeA Read(YamlReader reader)
+                {
+                    var value = reader.GetScalarValue();
+                    reader.Read();
+                    return new TypeA { Value = value };
+                }
+
+                public override void Write(YamlWriter writer, TypeA value)
+                {
+                    writer.WriteScalar(value.Value);
+                }
+            }
+
+            public sealed class ModelWithTypeB
+            {
+                public TypeB? Item { get; set; }
+            }
+
+            [YamlSerializable(typeof(ModelWithTypeB))]
+            [YamlSourceGenerationOptions(Converters = [typeof(TypeAConverter)])]
+            internal partial class TestContext : YamlSerializerContext
+            {
+            }
+            """;
+
+        var result = RunGenerator(source);
+
+        var diagnostics = result.Diagnostics
+            .Where(static d => d.Id == "SHARPYAML002")
+            .ToArray();
+
+        Assert.AreEqual(1, diagnostics.Length);
+        StringAssert.Contains(diagnostics[0].GetMessage(), "TypeB");
+    }
+
+    [TestMethod]
+    public void SHARPYAML002_IsSuppressed_WhenConverterInheritsFromAnotherConverter()
+    {
+        const string source = """
+            using SharpYaml.Serialization;
+
+            public sealed class CustomType
+            {
+                public string Value { get; set; } = string.Empty;
+            }
+
+            public class BaseCustomTypeConverter : YamlConverter<CustomType>
+            {
+                public override CustomType Read(YamlReader reader)
+                {
+                    var value = reader.GetScalarValue();
+                    reader.Read();
+                    return new CustomType { Value = value };
+                }
+
+                public override void Write(YamlWriter writer, CustomType value)
+                {
+                    writer.WriteScalar(value.Value);
+                }
+            }
+
+            public sealed class DerivedCustomTypeConverter : BaseCustomTypeConverter
+            {
+            }
+
+            public sealed class ModelWithCustomType
+            {
+                public CustomType? Item { get; set; }
+            }
+
+            [YamlSerializable(typeof(ModelWithCustomType))]
+            [YamlSourceGenerationOptions(Converters = [typeof(DerivedCustomTypeConverter)])]
+            internal partial class TestContext : YamlSerializerContext
+            {
+            }
+            """;
+
+        var result = RunGenerator(source);
+
+        var diagnostics = result.Diagnostics
+            .Where(static d => d.Id == "SHARPYAML002")
+            .ToArray();
+
+        Assert.AreEqual(0, diagnostics.Length, string.Join(Environment.NewLine, diagnostics.Select(static d => d.GetMessage())));
+    }
+
+    [TestMethod]
+    public void SHARPYAML002_IsSuppressed_WhenContextConverterHandlesNullableValueType()
+    {
+        const string source = """
+            using SharpYaml.Serialization;
+
+            public struct CustomStruct
+            {
+                public int Value { get; set; }
+            }
+
+            public sealed class CustomStructConverter : YamlConverter<CustomStruct>
+            {
+                public override CustomStruct Read(YamlReader reader)
+                {
+                    var value = reader.GetScalarValue();
+                    reader.Read();
+                    return new CustomStruct { Value = int.Parse(value) };
+                }
+
+                public override void Write(YamlWriter writer, CustomStruct value)
+                {
+                    writer.WriteScalar(value.Value.ToString());
+                }
+            }
+
+            public sealed class ModelWithNullableStruct
+            {
+                public CustomStruct? Item { get; set; }
+            }
+
+            [YamlSerializable(typeof(ModelWithNullableStruct))]
+            [YamlSourceGenerationOptions(Converters = [typeof(CustomStructConverter)])]
+            internal partial class TestContext : YamlSerializerContext
+            {
+            }
+            """;
+
+        var result = RunGenerator(source);
+
+        var diagnostics = result.Diagnostics
+            .Where(static d => d.Id == "SHARPYAML002")
+            .ToArray();
+
+        Assert.AreEqual(0, diagnostics.Length, string.Join(Environment.NewLine, diagnostics.Select(static d => d.GetMessage())));
+    }
+
     private static (Compilation OutputCompilation, Diagnostic[] Diagnostics, string GeneratedSource) RunGenerator(string source)
     {
         var parseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview);


### PR DESCRIPTION
## Motivation

The SHARPYAML002 diagnostic fires for member types that are not registered via `[YamlSerializable]` and are not built-in scalars. However, if a **custom converter** already handles the type, the diagnostic is a false positive — the generated POCO code path is never reached at runtime.

This is a practical blocker for types like `HttpMethod`, `IPEndPoint`, and `IPAddress`:

- Registering `HttpMethod` via `[YamlSerializable(typeof(HttpMethod))]` fails with **CS0176** because the generator accesses static properties via an instance reference.
- Registering `IPEndPoint` triggers a nested SHARPYAML002 for `IPAddress`, which in turn has its own members — creating an unsolvable cascade.

Applications that provide custom `YamlConverter<HttpMethod>` and `YamlConverter<IPEndPoint>` (registered via `[YamlSourceGenerationOptions(Converters = [...])]`) have no way to suppress the diagnostic today, forcing them to exclude affected types from the source-gen context entirely.

In a real-world application (Deucalion — an ASP.NET Core + SignalR monitoring app), this excludes **6 out of 10** model types from source generation due to transitive dependencies on converter-handled types.

## Solution

The SHARPYAML002 validation loop in `YamlSerializerContextGenerator.EmitContext()` now checks for converters before reporting the diagnostic. A new `IsTypeHandledByConverter` helper checks three conditions:

1. **Member-level `[YamlConverter(typeof(...))]` attribute** — if the member itself declares a converter, skip the entire member.
2. **Type-level `[YamlConverter(typeof(...))]` attribute** — if the member's type is decorated with `[YamlConverter]`, skip the diagnostic.
3. **Context-level `YamlConverter<T>` registration** — walks the base type chain of each converter in `[YamlSourceGenerationOptions(Converters = [...])]` to find `YamlConverter<T>` and matches `T` against the member type.

These checks apply to:
- Direct member types (e.g., `HttpMethod? Method`)
- Array/list element types (e.g., `List<CustomType>`)
- Dictionary value types (e.g., `Dictionary<string, CustomType>`)

`Nullable<T>` value types are unwrapped before matching (a `YamlConverter<MyStruct>` suppresses SHARPYAML002 for `MyStruct?` members).

## Tests

Added **9 new diagnostic tests** covering all suppression paths:

| Test | Scenario |
|------|----------|
| `SHARPYAML002_IsSuppressed_WhenContextLevelConverterHandlesMemberType` | Context-level `YamlConverter<T>` suppresses for direct member |
| `SHARPYAML002_IsSuppressed_WhenMemberHasYamlConverterAttribute` | `[YamlConverter]` on member suppresses |
| `SHARPYAML002_IsSuppressed_WhenTypeHasYamlConverterAttribute` | `[YamlConverter]` on type suppresses |
| `SHARPYAML002_IsSuppressed_WhenContextConverterHandlesArrayElementType` | Converter suppresses for `List<T>` elements |
| `SHARPYAML002_IsSuppressed_WhenContextConverterHandlesDictionaryValueType` | Converter suppresses for `Dictionary<K,V>` values |
| `SHARPYAML002_IsSuppressed_WhenConverterInheritsFromAnotherConverter` | Derived converter (inheriting from `YamlConverter<T>`) suppresses |
| `SHARPYAML002_IsSuppressed_WhenContextConverterHandlesNullableValueType` | `YamlConverter<T>` suppresses for `T?` members |
| `SHARPYAML002_StillFires_WhenNoConverterHandlesType` | Regression: diagnostic still fires without converter |
| `SHARPYAML002_StillFires_WhenConverterHandlesDifferentType` | Regression: converter for type A doesn't suppress for type B |

All 628 existing tests continue to pass.